### PR TITLE
Feature/76 add the ability to point to a specific

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,11 @@ conda-export:
 	pip freeze > requirements.txt
 
 # Build with poetry
-.PHONY: poetry-build
+.PHONY: poetry-build poetry-link
+poetry-link:
+	rm -f ${BUILD_FILES}
+	ln -s ${BUILD_DIR}/poetry_pyproject.toml pyproject.toml
+	ln -s ${BUILD_DIR}/poetry_poetry.lock poetry.lock
 poetry-build:
 	rm -f ${BUILD_FILES}
 	ln -s ${BUILD_DIR}/poetry_pyproject.toml pyproject.toml

--- a/src/vtp/core/common.py
+++ b/src/vtp/core/common.py
@@ -108,7 +108,10 @@ class Globals:
     }
 
     # Legitimate setters
-    _setters = []
+    @staticmethod
+    def set_electiondatadir(path):
+        """Will overwrite the default location of the ElectionData tree"""
+        Globals._config["ROOT_ELECTION_DATA_SUBDIR"] = path
 
     @staticmethod
     def get(name):
@@ -153,6 +156,74 @@ class Common:
                     new_argv.extend(["--" + key, str(value)])
             return new_argv
         return argv
+
+    @staticmethod
+    def add_blank_ballot(parser):
+        """Add blank_ballot option"""
+        parser.add_argument(
+            "-b",
+            "--blank_ballot",
+            help="overrides an address - specifies the specific blank ballot",
+        )
+
+    @staticmethod
+    def add_election_data(parser):
+        """Add election_data option"""
+        parser.add_argument(
+            "-e",
+            "--election_data",
+            help="specify a absolute or relative path to the ElectionData tree",
+        )
+
+    @staticmethod
+    def add_merge_contests(parser):
+        """Add merge_contests option"""
+        parser.add_argument(
+            "-m",
+            "--merge_contests",
+            action="store_true",
+            help="Will immediately merge the ballot contests (to main)",
+        )
+
+    @staticmethod
+    def add_minimum_cast_cache(parser):
+        """Add minimum_cast_cache option"""
+        parser.add_argument(
+            "--minimum_cast_cache",
+            type=int,
+            default=100,
+            help="the minimum number of cast ballots required prior to merging (def=100)",
+        )
+
+    @staticmethod
+    def add_printonly(parser):
+        """Add printonly option"""
+        parser.add_argument(
+            "-n",
+            "--printonly",
+            action="store_true",
+            help="will printonly and not write to disk (def=True)",
+        )
+
+    @staticmethod
+    def add_verbosity(parser):
+        """Add verbosity option"""
+        parser.add_argument(
+            "-v",
+            "--verbosity",
+            type=int,
+            default=3,
+            help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
+        )
+
+    @staticmethod
+    def verify_election_data(parsed_args):
+        """Verify election_data option"""
+        if not os.path.isdir(parsed_args.election_data):
+            raise ValueError(
+                f"The provided --election_data value ({parsed_args.election_data}) does not exist"
+            )
+        Globals.set_electiondatadir(parsed_args.election_data)
 
 
 # pylint: disable=too-few-public-methods   # ZZZ - remove this later

--- a/src/vtp/core/common.py
+++ b/src/vtp/core/common.py
@@ -167,7 +167,6 @@ class Common:
     def add_blank_ballot(parser):
         """Add blank_ballot option"""
         parser.add_argument(
-            "-b",
             "--blank_ballot",
             help="overrides an address - specifies the specific blank ballot",
         )

--- a/src/vtp/core/common.py
+++ b/src/vtp/core/common.py
@@ -122,6 +122,8 @@ class Globals:
 class Common:
     """Common functions without a better home at this time"""
 
+    # logging should only be configured once and only once (until a
+    # logger is set up)
     _configured = False
 
     @staticmethod
@@ -157,6 +159,10 @@ class Common:
             return new_argv
         return argv
 
+    # Tbe below are options that are shared across the various
+    # operations.  Options that are unique to one operation are
+    # located in that file.
+
     @staticmethod
     def add_blank_ballot(parser):
         """Add blank_ballot option"""
@@ -169,10 +175,12 @@ class Common:
     @staticmethod
     def add_election_data(parser):
         """Add election_data option"""
+        defval = Globals.get("ROOT_ELECTION_DATA_SUBDIR")
         parser.add_argument(
             "-e",
             "--election_data",
-            help="specify a absolute or relative path to the ElectionData tree",
+            default=defval,
+            help=f"specify a absolute or relative path to the ElectionData tree (def={defval})",
         )
 
     @staticmethod

--- a/src/vtp/ops/accept_ballot_operation.py
+++ b/src/vtp/ops/accept_ballot_operation.py
@@ -368,7 +368,13 @@ Either the location of the ballot_file or the associated address is required.
             # Use the specified address
             the_address = Address.create_address_from_args(
                 self.parsed_args,
-                ["verbosity", "printonly", "cast_ballot", "merge_contests"],
+                [
+                    "cast_ballot",
+                    "election_data",
+                    "merge_contests",
+                    "printonly",
+                    "verbosity",
+                ],
                 generic_address=True,
             )
             the_address.map_ggos(the_election_config, skip_ggos=True)

--- a/src/vtp/ops/accept_ballot_operation.py
+++ b/src/vtp/ops/accept_ballot_operation.py
@@ -64,6 +64,7 @@ Either the location of the ballot_file or the associated address is required.
         )
 
         Address.add_address_args(parser, True)
+        Common.add_election_data(parser)
         parser.add_argument(
             "-m",
             "--merge_contests",
@@ -74,21 +75,12 @@ Either the location of the ballot_file or the associated address is required.
             "--cast_ballot",
             help="overrides an address - specifies a specific cast ballot",
         )
-        parser.add_argument(
-            "-v",
-            "--verbosity",
-            type=int,
-            default=3,
-            help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-        )
-        parser.add_argument(
-            "-n",
-            "--printonly",
-            action="store_true",
-            help="will printonly and not write to disk (def=True)",
-        )
-
-        return parser.parse_args(safe_args)
+        Common.add_verbosity(parser)
+        Common.add_printonly(parser)
+        parsed_args = parser.parse_args(safe_args)
+        # Verify arguments
+        Common.verify_election_data(parsed_args)
+        return parsed_args
 
     def __init__(self, unparsed_args):
         """Only to module-ize the scripts and keep things simple and idiomatic."""

--- a/src/vtp/ops/cast_ballot_operation.py
+++ b/src/vtp/ops/cast_ballot_operation.py
@@ -29,8 +29,6 @@ import logging
 import os
 import pprint
 import random
-import sys
-import traceback
 
 import pyinputplus
 
@@ -187,18 +185,12 @@ demo mode, cast_ballot.py will randominly select choices.
                     "Warning - you selections have the following errors\n"
                     f"{err_string}"
                 )
-            # if still here, set the selection
-            try:
-                # Since it is possible to self adjudicate a contest, always
-                # explicitly clear the selection before adding
-                the_ballot.clear_selection(the_contest)
-                for sel in validated_selections:
-                    the_ballot.add_selection(the_contest, sel)
-            # pylint: disable=broad-except
-            except Exception:
-                # blow out of the internal pyinputplus try/catch
-                traceback.print_exc()
-                sys.exit(1)
+            # If still here, set the selection.  Since it is possible to self
+            # adjudicate a contest, always explicitly clear the selection
+            # before adding
+            the_ballot.clear_selection(the_contest)
+            for sel in validated_selections:
+                the_ballot.add_selection(the_contest, sel)
 
         if tally == "plurality":
             if max_votes > 1:

--- a/src/vtp/ops/cast_ballot_operation.py
+++ b/src/vtp/ops/cast_ballot_operation.py
@@ -76,29 +76,19 @@ demo mode, cast_ballot.py will randominly select choices.
         # ZZZ - cloaked contests are enabled at cast_ballot time
         #    parser.add_argument('-k', "--cloak", action="store_true",
         #                            help="if possible provide a cloaked ballot offset")
+        Common.add_election_data(parser)
         parser.add_argument(
             "--demo_mode",
             action="store_true",
             help="set demo mode to automatically cast random ballots",
         )
-        parser.add_argument(
-            "--blank_ballot",
-            help="overrides an address - specifies the specific blank ballot",
-        )
-        parser.add_argument(
-            "-v",
-            "--verbosity",
-            type=int,
-            default=3,
-            help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-        )
-        parser.add_argument(
-            "-n",
-            "--printonly",
-            action="store_true",
-            help="will printonly and not write to disk (def=True)",
-        )
-        return parser.parse_args(safe_args)
+        Common.add_blank_ballot(parser)
+        Common.add_verbosity(parser)
+        Common.add_printonly(parser)
+        parsed_args = parser.parse_args(safe_args)
+        # Verify arguments
+        Common.verify_election_data(parsed_args)
+        return parsed_args
 
     def __init__(self, unparsed_args):
         """

--- a/src/vtp/ops/cast_ballot_operation.py
+++ b/src/vtp/ops/cast_ballot_operation.py
@@ -299,7 +299,13 @@ demo mode, cast_ballot.py will randominly select choices.
             # Use the specified address
             the_address = Address.create_address_from_args(
                 self.parsed_args,
-                ["verbosity", "printonly", "blank_ballot", "demo_mode"],
+                [
+                    "blank_ballot",
+                    "demo_mode",
+                    "election_data",
+                    "printonly",
+                    "verbosity",
+                ],
             )
             the_address.map_ggos(the_election_config)
             # get the ballot for the specified address

--- a/src/vtp/ops/create_blank_ballot_operation.py
+++ b/src/vtp/ops/create_blank_ballot_operation.py
@@ -92,7 +92,7 @@ class CreateBlankBallotOperation:
         # imported somehow. And all that comes later - for now just map an
         # address to a town.
         the_address = Address.create_address_from_args(
-            self.parsed_args, ["verbosity", "printonly", "language"]
+            self.parsed_args, ["election_data", "language", "printonly", "verbosity"]
         )
         the_address.map_ggos(the_election_config)
 

--- a/src/vtp/ops/create_blank_ballot_operation.py
+++ b/src/vtp/ops/create_blank_ballot_operation.py
@@ -55,26 +55,19 @@ class CreateBlankBallotOperation:
     """,
         )
         Address.add_address_args(parser)
+        Common.add_election_data(parser)
         parser.add_argument(
             "-l",
             "--language",
             default="en",
             help="will print the ballot in the specified language",
         )
-        parser.add_argument(
-            "-v",
-            "--verbosity",
-            type=int,
-            default=3,
-            help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-        )
-        parser.add_argument(
-            "-n",
-            "--printonly",
-            action="store_true",
-            help="will printonly and not write to disk (def=True)",
-        )
-        return parser.parse_args(safe_args)
+        Common.add_verbosity(parser)
+        Common.add_printonly(parser)
+        parsed_args = parser.parse_args(safe_args)
+        # Verify arguments
+        Common.verify_election_data(parsed_args)
+        return parsed_args
 
     def __init__(self, unparsed_args):
         """Only to module-ize the scripts and keep things simple and idiomatic."""

--- a/src/vtp/ops/generate_all_blank_ballots_operation.py
+++ b/src/vtp/ops/generate_all_blank_ballots_operation.py
@@ -57,21 +57,13 @@ class GenerateAllBlankBallotsOperation:
     """,
         )
 
-        parser.add_argument(
-            "-v",
-            "--verbosity",
-            type=int,
-            default=3,
-            help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-        )
-        parser.add_argument(
-            "-n",
-            "--printonly",
-            action="store_true",
-            help="will printonly and not write to disk (def=True)",
-        )
-
-        return parser.parse_args(safe_args)
+        Common.add_election_data(parser)
+        Common.add_verbosity(parser)
+        Common.add_printonly(parser)
+        parsed_args = parser.parse_args(safe_args)
+        # Verify arguments
+        Common.verify_election_data(parsed_args)
+        return parsed_args
 
     def __init__(self, unparsed_args):
         """Only to module-ize the scripts and keep things simple and idiomatic."""

--- a/src/vtp/ops/merge_contests_operation.py
+++ b/src/vtp/ops/merge_contests_operation.py
@@ -60,16 +60,14 @@ class MergeContestsOperation:
     branch.
     """,
         )
+        Common.add_election_data(parser)
         parser.add_argument(
-            "-b", "--branch", default="", help="specify a specific branch to merge"
+            "-b",
+            "--branch",
+            default="",
+            help="specify a specific branch to merge",
         )
-        parser.add_argument(
-            "-m",
-            "--minimum_cast_cache",
-            type=int,
-            default=100,
-            help="the minimum number of cast ballots required prior to merging (def=100)",
-        )
+        Common.add_minimum_cast_cache(parser)
         parser.add_argument(
             "-f",
             "--flush",
@@ -82,20 +80,12 @@ class MergeContestsOperation:
             action="store_true",
             help="will merge remote branches instead of local branches",
         )
-        parser.add_argument(
-            "-v",
-            "--verbosity",
-            type=int,
-            default=3,
-            help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-        )
-        parser.add_argument(
-            "-n",
-            "--printonly",
-            action="store_true",
-            help="will printonly and not write to disk (def=True)",
-        )
-        return parser.parse_args(safe_args)
+        Common.add_verbosity(parser)
+        Common.add_printonly(parser)
+        parsed_args = parser.parse_args(safe_args)
+        # Verify arguments
+        Common.verify_election_data(parsed_args)
+        return parsed_args
 
     def __init__(self, unparsed_args):
         """Only to module-ize the scripts and keep things simple and idiomatic."""

--- a/src/vtp/ops/run_mock_election_operation.py
+++ b/src/vtp/ops/run_mock_election_operation.py
@@ -389,6 +389,7 @@ mock to a single ballot N times.
                 [
                     "blank_ballot",
                     "device",
+                    "election_data",
                     "minimum_cast_cache",
                     "flush_mode",
                     "iterations",

--- a/src/vtp/ops/run_mock_election_operation.py
+++ b/src/vtp/ops/run_mock_election_operation.py
@@ -109,6 +109,7 @@ mock to a single ballot N times.
         # parser.add_argument.  It is python.
         #
         # fmt: off
+        # pylint: disable=line-too-long
         parser.add_argument(
             "-f",
             "--flush_mode",

--- a/src/vtp/ops/run_mock_election_operation.py
+++ b/src/vtp/ops/run_mock_election_operation.py
@@ -87,23 +87,15 @@ mock to a single ballot N times.
         )
 
         Address.add_address_args(parser)
-        parser.add_argument(
-            "--blank_ballot",
-            help="overrides an address - specifies the specific blank ballot",
-        )
+        Common.add_election_data(parser)
+        Common.add_blank_ballot(parser)
         parser.add_argument(
             "-d",
             "--device",
             default="",
             help="specify a specific VC local device (scanner or server or both) to mock",
         )
-        parser.add_argument(
-            "-m",
-            "--minimum_cast_cache",
-            type=int,
-            default=100,
-            help="the minimum number of cast ballots required prior to merging (def=100)",
-        )
+        Common.add_minimum_cast_cache(parser)
         # Note - the black formatter will by default break the help
         # line below into two lines via a '()', which breaks the
         # parser.add_argument.  It is python.
@@ -116,7 +108,7 @@ mock to a single ballot N times.
             type=int,
             default=0,
             help="will either not flush (0 - default), flush on exit (1), or flush on each iteration (2)",
-        )
+            )
         # fmt: on
         parser.add_argument(
             "-i",
@@ -132,23 +124,12 @@ mock to a single ballot N times.
             default=10,
             help="the number of minutes for the server app to run (def=10)",
         )
-        parser.add_argument(
-            "-v",
-            "--verbosity",
-            type=int,
-            default=3,
-            help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-        )
-        parser.add_argument(
-            "-n",
-            "--printonly",
-            action="store_true",
-            help="will printonly and not write to disk (def=True)",
-        )
-
+        Common.add_verbosity(parser)
+        Common.add_printonly(parser)
         parsed_args = parser.parse_args(safe_args)
 
         # Validate required args
+        Common.verify_election_data(parsed_args)
         if parsed_args.device not in ["scanner", "server", "both"]:
             raise ValueError(
                 "The --device parameter only accepts 'device' or 'server' "

--- a/src/vtp/ops/setup_vtp_demo_operation.py
+++ b/src/vtp/ops/setup_vtp_demo_operation.py
@@ -67,6 +67,7 @@ demo this script will create a new GUID based FASTapi clone and return
 the GUID.
 """,
         )
+        Common.add_election_data(parser)
         parser.add_argument(
             "-s",
             "--scanners",
@@ -86,21 +87,11 @@ the GUID.
             default="/opt/VoteTrackerPlus/demo.01",
             help="specify the location of VTP demo (def=/opt/VoteTrackerPlus/demo.01)",
         )
-        parser.add_argument(
-            "-v",
-            "--verbosity",
-            type=int,
-            default=3,
-            help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-        )
-        parser.add_argument(
-            "-n",
-            "--printonly",
-            action="store_true",
-            help="will printonly and not write to disk (def=True)",
-        )
+        Common.add_verbosity(parser)
+        Common.add_printonly(parser)
         parsed_args = parser.parse_args(safe_args)
         # Validate required args
+        Common.verify_election_data(parsed_args)
         if parsed_args.scanners < 1 or parsed_args.scanners > 16:
             raise ValueError(
                 "The demo needs at least one TVP scanner app "

--- a/src/vtp/ops/show_contests_operation.py
+++ b/src/vtp/ops/show_contests_operation.py
@@ -51,28 +51,19 @@ class ShowContestsOperation:
     will print the CVRs (Cast Vote Records) for the supplied contest(s)
     """,
         )
-
+        Common.add_election_data(parser)
         parser.add_argument(
             "-c",
             "--contest-check",
             help="a comma separate list of contests digests to validate/display",
         )
-        parser.add_argument(
-            "-v",
-            "--verbosity",
-            type=int,
-            default=3,
-            help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-        )
-        parser.add_argument(
-            "-n",
-            "--printonly",
-            action="store_true",
-            help="will printonly and not write to disk (def=True)",
-        )
+
+        Common.add_verbosity(parser)
+        Common.add_printonly(parser)
         parsed_args = parser.parse_args(safe_args)
 
         # Validate required args
+        Common.verify_election_data(parsed_args)
         if not parsed_args.contest_check:
             raise ValueError("The contest check is required")
         if not bool(re.match("^[0-9a-f,]", parsed_args.contest_check)):

--- a/src/vtp/ops/tally_contests_operation.py
+++ b/src/vtp/ops/tally_contests_operation.py
@@ -69,6 +69,7 @@ tallying across git submodules/repos.
 """,
         )
 
+        Common.add_election_data(parser)
         parser.add_argument(
             "-c",
             "--contest_uid",
@@ -87,19 +88,11 @@ tallying across git submodules/repos.
             action="store_true",
             help="Before tallying the votes, pull the ElectionData repo",
         )
-        parser.add_argument(
-            "-v",
-            "--verbosity",
-            type=int,
-            default=3,
-            help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-        )
-        #    parser.add_argument("-n", "--printonly", action="store_true",
-        #                            help="will printonly and not write to disk (def=True)")
-
+        Common.add_verbosity(parser)
         parsed_args = parser.parse_args(safe_args)
 
         # Validate required args
+        Common.verify_election_data(parsed_args)
         if parsed_args.track_contests:
             if not bool(re.match("^[0-9a-f,]", parsed_args.track_contests)):
                 raise ValueError(

--- a/src/vtp/ops/verify_ballot_receipt_operation.py
+++ b/src/vtp/ops/verify_ballot_receipt_operation.py
@@ -376,7 +376,14 @@ check row is provided.
             # Need to use the address to locate the last created receipt file
             the_address = Address.create_address_from_args(
                 self.parsed_args,
-                ["do_not_pull", "verbosity", "receipt_file", "row", "cvr"],
+                [
+                    "cvr",
+                    "do_not_pull",
+                    "election_data",
+                    "receipt_file",
+                    "row",
+                    "verbosity",
+                ],
                 generic_address=True,
             )
             the_address.map_ggos(the_election_config, skip_ggos=True)

--- a/src/vtp/ops/verify_ballot_receipt_operation.py
+++ b/src/vtp/ops/verify_ballot_receipt_operation.py
@@ -68,6 +68,7 @@ check row is provided.
         )
 
         Address.add_address_args(parser, True)
+        Common.add_election_data(parser)
         parser.add_argument(
             "-f",
             "--receipt_file",
@@ -92,19 +93,12 @@ check row is provided.
             action="store_true",
             help="Before tallying the votes, pull the ElectionData repo",
         )
-        parser.add_argument(
-            "-v",
-            "--verbosity",
-            type=int,
-            default=3,
-            help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-        )
-        #    parser.add_argument("-n", "--printonly", action="store_true",
-        #                            help="will printonly and not write to disk (def=True)")
+        Common.add_verbosity(parser)
 
         parsed_args = parser.parse_args(safe_args)
 
         # Validate required args
+        Common.verify_election_data(parsed_args)
         if not (parsed_args.receipt_file or (parsed_args.state and parsed_args.town)):
             raise ValueError(
                 "Either an explicit or implicit (via an address) receipt file must be provided"

--- a/src/vtp/ops/vote_operation.py
+++ b/src/vtp/ops/vote_operation.py
@@ -61,30 +61,15 @@ class VoteOperation:
         )
 
         Address.add_address_args(parser)
-        parser.add_argument(
-            "-m",
-            "--merge_contests",
-            action="store_true",
-            help="Will immediately merge the ballot contests (to main)",
-        )
-        parser.add_argument(
-            "--blank_ballot",
-            help="overrides an address - specifies the specific blank ballot",
-        )
-        parser.add_argument(
-            "-v",
-            "--verbosity",
-            type=int,
-            default=3,
-            help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-        )
-        parser.add_argument(
-            "-n",
-            "--printonly",
-            action="store_true",
-            help="will printonly and not write to disk (def=True)",
-        )
-        return parser.parse_args(safe_args)
+        Common.add_election_data(parser)
+        Common.add_merge_contests(parser)
+        Common.add_blank_ballot(parser)
+        Common.add_verbosity(parser)
+        Common.add_printonly(parser)
+        parsed_args = parser.parse_args(safe_args)
+        # Validate required args
+        Common.verify_election_data(parsed_args)
+        return parsed_args
 
     def __init__(self, unparsed_args):
         """Only to module-ize the scripts and keep things simple and idiomatic."""


### PR DESCRIPTION
When the design switched from invoke-by-subprocess to invoke-by-import, that switched the design from one where every operation instance was in a separate process to one where all operations share the same process.  Yes the python namespace had to be altered so that each operation was in its own namespace (switch from the global namespace to a class namespace with each instance being separate), but now the one process has to be able to run git operations in different ElectionData clones.

(Well, maybe not depending on what the web server is doing, but I don't know that design aspect yet.)

So, add another generic option, --election_data, which can override the default "." and point to a different git clone-workspace in which to run commands.  FWIIW I have been wanting to do this to make testing and debugging easier on the finger tips.