### PR TITLE
Separate CLI and operations.

### DIFF
--- a/src/vtp/cli/_arguments.py
+++ b/src/vtp/cli/_arguments.py
@@ -123,12 +123,38 @@ class Arguments:
             - All arguments that are not address fields
         """
         # Convert namespace to a dictionary.
-        parsed_arguments = vars(parsed_arguments)
+        args = vars(parsed_arguments)
+        args = Arguments._process_generic_address(args)
         addresses = {}
         non_addresses = {}
-        for key, value in parsed_arguments.items():
+        for key, value in args.items():
             if key in address_fields:
                 addresses[key] = value
             else:
                 non_addresses[key] = value
         return addresses, non_addresses
+
+    @staticmethod
+    def _process_generic_address(args: dict):
+        """Convert a generic address in parsed arguments, if present.
+
+        A non-generic address split into street and street number.
+
+        Parameters:
+            args: Parsed arguments.
+                Modified in place.
+
+        Returns:
+            Original arguments, possibly modified.
+        """
+        # If the 'address' field is present the argument is generic
+        if "address" in args:
+            if args["address"]:
+                number, street = Address.convert_address_to_num_street(args["address"])
+                args["number"] = number
+                args["street"] = street
+            del args["address"]
+        # FIXME: Where is this used?
+        # else:
+        #     args["generic_address"] = True
+        return args

--- a/src/vtp/cli/_arguments.py
+++ b/src/vtp/cli/_arguments.py
@@ -109,13 +109,14 @@ class Arguments:
     def separate_addresses(
         parsed_arguments: argparse.Namespace,
         # TODO: Fix scope of 'Address._keys'. add 'tuple[str]'
-        address_fields=Address._keys,
+        address_fields=None,
     ):
         """Separate addresses and non-addresses from parsed arguments.
 
         Parameters:
             parsed_arguments: Arguments extracted by argument parsing.
             address_fields: List of keys for addresses.
+                default: All fields of addresses.
 
         Returns:
             2-tuple of lists of arguments:
@@ -123,38 +124,5 @@ class Arguments:
             - All arguments that are not address fields
         """
         # Convert namespace to a dictionary.
-        args = vars(parsed_arguments)
-        args = Arguments._process_generic_address(args)
-        addresses = {}
-        non_addresses = {}
-        for key, value in args.items():
-            if key in address_fields:
-                addresses[key] = value
-            else:
-                non_addresses[key] = value
-        return addresses, non_addresses
-
-    @staticmethod
-    def _process_generic_address(args: dict):
-        """Convert a generic address in parsed arguments, if present.
-
-        A non-generic address split into street and street number.
-
-        Parameters:
-            args: Parsed arguments.
-                Modified in place.
-
-        Returns:
-            Original arguments, possibly modified.
-        """
-        # If the 'address' field is present the argument is generic
-        if "address" in args:
-            if args["address"]:
-                number, street = Address.convert_address_to_num_street(args["address"])
-                args["number"] = number
-                args["street"] = street
-            del args["address"]
-        # FIXME: Where is this used?
-        # else:
-        #     args["generic_address"] = True
-        return args
+        args = dict(vars(parsed_arguments))
+        return Address.separate_addresses_from_arguments(args)

--- a/src/vtp/cli/_arguments.py
+++ b/src/vtp/cli/_arguments.py
@@ -40,14 +40,23 @@ class Arguments:
             parser.add_argument(
                 "-a",
                 "--address",
+                default = "",
                 help="the number and name of the street address (space separated)",
             )
             parser.add_argument(
-                "-b", "--substreet", help="the substreet field of an address"
+                "-b", "--substreet",
+                default = "",
+                help="the substreet field of an address"
             )
-        parser.add_argument("-t", "--town", help="the town field of an address")
         parser.add_argument(
-            "-s", "--state", help="the state/province field of an address"
+            "-t", "--town",
+            default = "",
+            help="the town field of an address"
+        )
+        parser.add_argument(
+            "-s", "--state",
+            default = "",
+            help="the state/province field of an address"
         )
 
     @staticmethod

--- a/src/vtp/cli/_arguments.py
+++ b/src/vtp/cli/_arguments.py
@@ -28,6 +28,29 @@ class Arguments:
     # Note: If commands were classes this would be a base class.
 
     @staticmethod
+    def add_address(parser, generic_address=False):
+        """Add standard address program options"""
+        # parser.add_argument('-c', "--csv",
+        #     help="a comma separated address")
+        #        parser.add_argument('-r', "--street",
+        #     help="the street/road field of an address, in which case the address is the number")
+        # parser.add_argument('-z', "--zipcode",
+        #     help="the zipcode field of an address")
+        if not generic_address:
+            parser.add_argument(
+                "-a",
+                "--address",
+                help="the number and name of the street address (space separated)",
+            )
+            parser.add_argument(
+                "-b", "--substreet", help="the substreet field of an address"
+            )
+        parser.add_argument("-t", "--town", help="the town field of an address")
+        parser.add_argument(
+            "-s", "--state", help="the state/province field of an address"
+        )
+
+    @staticmethod
     def add_merge_contests(parser):
         parser.add_argument(
             "-m",

--- a/src/vtp/cli/_arguments.py
+++ b/src/vtp/cli/_arguments.py
@@ -17,6 +17,11 @@
 
 """Argument handling."""
 
+import argparse
+
+from vtp.core.address import Address
+
+
 class Arguments:
 
     """Arguments common to multiple commands.
@@ -96,3 +101,31 @@ class Arguments:
             default=3,
             help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
         )
+
+    @staticmethod
+    def separate_addresses(
+        parsed_arguments: argparse.Namespace,
+        # TODO: Fix scope of 'Address._keys'. add 'tuple[str]'
+        address_fields = Address._keys,
+    ):
+        """Separate addresses and non-addresses from parsed arguments.
+
+        Parameters:
+            parsed_arguments: Arguments extracted by argument parsing.
+            address_fields: List of keys for addresses.
+    
+        Returns:
+            2-tuple of lists of arguments:
+            - All arguments that are address fields
+            - All arguments that are not address fields
+        """
+        # Convert namespace to a dictionary.
+        parsed_arguments = vars(parsed_arguments)
+        addresses = {}
+        non_addresses = {}
+        for key, value in parsed_arguments.items():
+            if key in address_fields:
+                addresses[key] = value
+            else:
+                non_addresses[key] = value
+        return addresses, non_addresses

--- a/src/vtp/cli/_arguments.py
+++ b/src/vtp/cli/_arguments.py
@@ -45,23 +45,26 @@ class Arguments:
             parser.add_argument(
                 "-a",
                 "--address",
-                default = "",
+                default="",
                 help="the number and name of the street address (space separated)",
             )
             parser.add_argument(
-                "-b", "--substreet",
-                default = "",
-                help="the substreet field of an address"
+                "-b",
+                "--substreet",
+                default="",
+                help="the substreet field of an address",
             )
         parser.add_argument(
-            "-t", "--town",
-            default = "",
-            help="the town field of an address"
+            "-t",
+            "--town",
+            default="",
+            help="the town field of an address",
         )
         parser.add_argument(
-            "-s", "--state",
-            default = "",
-            help="the state/province field of an address"
+            "-s",
+            "--state",
+            default="",
+            help="the state/province field of an address",
         )
 
     @staticmethod
@@ -74,7 +77,7 @@ class Arguments:
         )
 
     @staticmethod
-    def add_minimum_cast_cache(parser, default = 100):
+    def add_minimum_cast_cache(parser, default=100):
         parser.add_argument(
             "-m",
             "--minimum_cast_cache",
@@ -106,14 +109,14 @@ class Arguments:
     def separate_addresses(
         parsed_arguments: argparse.Namespace,
         # TODO: Fix scope of 'Address._keys'. add 'tuple[str]'
-        address_fields = Address._keys,
+        address_fields=Address._keys,
     ):
         """Separate addresses and non-addresses from parsed arguments.
 
         Parameters:
             parsed_arguments: Arguments extracted by argument parsing.
             address_fields: List of keys for addresses.
-    
+
         Returns:
             2-tuple of lists of arguments:
             - All arguments that are address fields

--- a/src/vtp/cli/_arguments.py
+++ b/src/vtp/cli/_arguments.py
@@ -17,8 +17,6 @@
 
 """Argument handling."""
 
-import argparse
-
 from vtp.core.address import Address
 
 

--- a/src/vtp/cli/_arguments.py
+++ b/src/vtp/cli/_arguments.py
@@ -1,0 +1,66 @@
+#  VoteTrackerPlus
+#   Copyright (C) 2022 Sandy Currier
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, write to the Free Software Foundation, Inc.,
+#   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""Argument handling."""
+
+class Arguments:
+
+    """Arguments common to multiple commands.
+
+    Parameters are kept minimal but are provided when one command may have a
+    different value than another.
+    """
+
+    # Note: If commands were classes this would be a base class.
+
+    @staticmethod
+    def add_merge_contests(parser):
+        parser.add_argument(
+            "-m",
+            "--merge_contests",
+            action="store_true",
+            help="Will immediately merge the ballot contests (to main)",
+        )
+
+    @staticmethod
+    def add_minimum_cast_cache(parser, default = 100):
+        parser.add_argument(
+            "-m",
+            "--minimum_cast_cache",
+            type=int,
+            default=default,
+            help="the minimum number of cast ballots required prior to merging (def=100)",
+        )
+
+    @staticmethod
+    def add_print_only(parser):
+        parser.add_argument(
+            "-n",
+            "--printonly",
+            action="store_true",
+            help="will printonly and not write to disk (def=True)",
+        )
+
+    @staticmethod
+    def add_verbosity(parser):
+        parser.add_argument(
+            "-v",
+            "--verbosity",
+            type=int,
+            default=3,
+            help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
+        )

--- a/src/vtp/cli/accept_ballot.py
+++ b/src/vtp/cli/accept_ballot.py
@@ -49,7 +49,8 @@ In addition a voter's ballot receipt and offset are optionally printed.
 Either the location of the ballot_file or the associated address is required.
 """,
     )
-    Arguments.add_address(parser, True)
+    generic_address = True
+    Arguments.add_address(parser, generic_address)
     Arguments.add_merge_contests(parser)
     parser.add_argument(
         "--cast_ballot",
@@ -59,10 +60,9 @@ Either the location of the ballot_file or the associated address is required.
     Arguments.add_verbosity(parser)
     Arguments.add_print_only(parser)
 
-    args = parser.parse_args(safe_args)
-    address_args, parsed = Arguments.separate_addresses(args)
-    parsed["address"] = Address(generic_address=True, **address_args)
-    return parsed
+    parsed_args = Arguments.parse_arguments(parser, safe_args, generic_address)
+    # Validation, if any is needed, goes here
+    return parsed_args
 
 
 # pylint: disable=duplicate-code

--- a/src/vtp/cli/accept_ballot.py
+++ b/src/vtp/cli/accept_ballot.py
@@ -27,6 +27,7 @@ import argparse
 import sys
 
 # Local imports
+from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.accept_ballot_operation import AcceptBallotOperation
 
@@ -48,17 +49,19 @@ In addition a voter's ballot receipt and offset are optionally printed.
 Either the location of the ballot_file or the associated address is required.
 """,
     )
-
     Arguments.add_address(parser, True)
     Arguments.add_merge_contests(parser)
     parser.add_argument(
-        "--cast_ballot",
+        "--cast_ballot", default = "",
         help="overrides an address - specifies a specific cast ballot",
     )
     Arguments.add_verbosity(parser)
     Arguments.add_print_only(parser)    
 
-    return parser.parse_args(safe_args)
+    args = parser.parse_args(safe_args)
+    address_args, parsed = Arguments.separate_addresses(args)
+    parsed["address"] = Address(generic_address = True, **address_args)
+    return parsed
 
 
 # pylint: disable=duplicate-code
@@ -66,7 +69,7 @@ def main():
     """Entry point for 'accept-ballot'."""
 
     args = parse_arguments(sys.argv[1:])
-    op = AcceptBallotOperation(args)
+    op = AcceptBallotOperation(**args)
     op.run()
 
 

--- a/src/vtp/cli/accept_ballot.py
+++ b/src/vtp/cli/accept_ballot.py
@@ -52,15 +52,16 @@ Either the location of the ballot_file or the associated address is required.
     Arguments.add_address(parser, True)
     Arguments.add_merge_contests(parser)
     parser.add_argument(
-        "--cast_ballot", default = "",
+        "--cast_ballot",
+        default="",
         help="overrides an address - specifies a specific cast ballot",
     )
     Arguments.add_verbosity(parser)
-    Arguments.add_print_only(parser)    
+    Arguments.add_print_only(parser)
 
     args = parser.parse_args(safe_args)
     address_args, parsed = Arguments.separate_addresses(args)
-    parsed["address"] = Address(generic_address = True, **address_args)
+    parsed["address"] = Address(generic_address=True, **address_args)
     return parsed
 
 

--- a/src/vtp/cli/accept_ballot.py
+++ b/src/vtp/cli/accept_ballot.py
@@ -26,11 +26,11 @@ Run with '--help' for usage information.
 import argparse
 import sys
 
-# Local imports
-from vtp.core.address import Address
+# Project imports
 from vtp.core.common import Common
 from vtp.ops.accept_ballot_operation import AcceptBallotOperation
 
+# Local imports
 from ._arguments import Arguments
 
 

--- a/src/vtp/cli/accept_ballot.py
+++ b/src/vtp/cli/accept_ballot.py
@@ -17,9 +17,9 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""accept_ballot.py - command line level script to accept a ballot.
+"""Command line script to accept a ballot.
 
-See 'accept_ballot.py -h' for usage information.
+Run with '--help' for usage information.
 """
 
 # Standard imports
@@ -78,13 +78,7 @@ Either the location of the ballot_file or the associated address is required.
 
 # pylint: disable=duplicate-code
 def main():
-    """
-    Called via a python local install entrypoint or by running this
-    file.  Simply wraps the scripts constructor and calls the run
-    method.  See the script's help output or read the
-    vtp.ops.accept_ballot_operation.py (argparse) description in the
-    source file.
-    """
+    """Entry point for 'accept-ballot'."""
 
     args = parse_arguments(sys.argv[1:])
     op = AcceptBallotOperation(args)

--- a/src/vtp/cli/accept_ballot.py
+++ b/src/vtp/cli/accept_ballot.py
@@ -27,7 +27,6 @@ import argparse
 import sys
 
 # Local imports
-from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.accept_ballot_operation import AcceptBallotOperation
 
@@ -50,7 +49,7 @@ Either the location of the ballot_file or the associated address is required.
 """,
     )
 
-    Address.add_address_args(parser, True)
+    Arguments.add_address(parser, True)
     Arguments.add_merge_contests(parser)
     parser.add_argument(
         "--cast_ballot",

--- a/src/vtp/cli/accept_ballot.py
+++ b/src/vtp/cli/accept_ballot.py
@@ -22,9 +22,58 @@
 See 'accept_ballot.py -h' for usage information.
 """
 
+# Standard imports
+import argparse
 import sys
 
+# Local imports
+from vtp.core.address import Address
+from vtp.core.common import Common
 from vtp.ops.accept_ballot_operation import AcceptBallotOperation
+
+
+def parse_arguments(argv):
+    safe_args = Common.cast_thing_to_list(argv)
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""
+Will run the git based workflow on a VTP scanner node to accept the json
+rendering of the cast vote record of a voter's ballot. The json file is read,
+the contests are extraced and submitted to separate git branches, one per
+contest, and pushed back to the Voter Center's VTP remote.
+
+In addition a voter's ballot receipt and offset are optionally printed.
+
+Either the location of the ballot_file or the associated address is required.
+""",
+    )
+
+    Address.add_address_args(parser, True)
+    parser.add_argument(
+        "-m",
+        "--merge_contests",
+        action="store_true",
+        help="Will immediately merge the ballot contests (to main)",
+    )
+    parser.add_argument(
+        "--cast_ballot",
+        help="overrides an address - specifies a specific cast ballot",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbosity",
+        type=int,
+        default=3,
+        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
+    )
+    parser.add_argument(
+        "-n",
+        "--printonly",
+        action="store_true",
+        help="will printonly and not write to disk (def=True)",
+    )
+
+    return parser.parse_args(safe_args)
 
 
 # pylint: disable=duplicate-code
@@ -37,9 +86,9 @@ def main():
     source file.
     """
 
-    # do it
-    abo = AcceptBallotOperation(sys.argv[1:])
-    abo.run()
+    args = parse_arguments(sys.argv[1:])
+    op = AcceptBallotOperation(args)
+    op.run()
 
 
 # If called directly via this file

--- a/src/vtp/cli/accept_ballot.py
+++ b/src/vtp/cli/accept_ballot.py
@@ -31,6 +31,8 @@ from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.accept_ballot_operation import AcceptBallotOperation
 
+from ._arguments import Arguments
+
 
 def parse_arguments(argv):
     safe_args = Common.cast_thing_to_list(argv)
@@ -49,29 +51,13 @@ Either the location of the ballot_file or the associated address is required.
     )
 
     Address.add_address_args(parser, True)
-    parser.add_argument(
-        "-m",
-        "--merge_contests",
-        action="store_true",
-        help="Will immediately merge the ballot contests (to main)",
-    )
+    Arguments.add_merge_contests(parser)
     parser.add_argument(
         "--cast_ballot",
         help="overrides an address - specifies a specific cast ballot",
     )
-    parser.add_argument(
-        "-v",
-        "--verbosity",
-        type=int,
-        default=3,
-        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-    )
-    parser.add_argument(
-        "-n",
-        "--printonly",
-        action="store_true",
-        help="will printonly and not write to disk (def=True)",
-    )
+    Arguments.add_verbosity(parser)
+    Arguments.add_print_only(parser)    
 
     return parser.parse_args(safe_args)
 

--- a/src/vtp/cli/cast_ballot.py
+++ b/src/vtp/cli/cast_ballot.py
@@ -73,10 +73,9 @@ demo mode, cast_ballot.py will randominly select choices.
     Arguments.add_verbosity(parser)
     Arguments.add_print_only(parser)
 
-    args = parser.parse_args(safe_args)
-    address_args, parsed = Arguments.separate_addresses(args)
-    parsed["address"] = Address(**address_args)
-    return parsed
+    parsed_args = Arguments.parse_arguments(parser, safe_args)
+    # Validation, if any is needed, goes here
+    return parsed_args
 
 
 # pylint: disable=duplicate-code

--- a/src/vtp/cli/cast_ballot.py
+++ b/src/vtp/cli/cast_ballot.py
@@ -17,9 +17,9 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""cast_ballot.py - command line level test script to automatically cast a ballot.
+"""Command line script to automatically cast a ballot.
 
-See 'cast_ballot.py -h' for usage information.
+Run with '--help' for usage information.
 """
 
 # Standard imports
@@ -86,13 +86,7 @@ demo mode, cast_ballot.py will randominly select choices.
 
 # pylint: disable=duplicate-code
 def main():
-    """
-    Called via a python local install entrypoint or by running this
-    file.  Simply wraps the scripts constructor and calls the run
-    method.  See the script's help output or read the
-    vtp.ops.cast_ballot_operation.py (argparse) description in the
-    source file.
-    """
+    """Entry point for 'cast-ballot'."""
 
     args = parse_arguments(sys.argv[1:])
     op = CastBallotOperation(args)

--- a/src/vtp/cli/cast_ballot.py
+++ b/src/vtp/cli/cast_ballot.py
@@ -21,9 +21,67 @@
 
 See 'cast_ballot.py -h' for usage information.
 """
+
+# Standard imports
+import argparse
 import sys
 
+# Local imports
+from vtp.core.address import Address
+from vtp.core.common import Common
 from vtp.ops.cast_ballot_operation import CastBallotOperation
+
+
+def parse_arguments(argv):
+    """
+    Parse command line arguments.  This can be called either with
+    sys.argv sans the first arg which is the 'script name', in
+    which case argv is a list of strings, or with a dictionary, in
+    which case is converted to a list of strings.
+
+    So to match native argparse argv parsing, if a dict value is a
+    boolean, the value is removed from the list and the key is
+    either kept (True) or deleted (False).  If the value is None,
+    the key is removed.
+    """
+
+    safe_args = Common.cast_thing_to_list(argv)
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""
+Given either an address or a specific blank ballot, will either read a
+blank ballot and allow a user to manually select choices or when in
+demo mode, cast_ballot.py will randominly select choices.
+""",
+    )
+
+    Address.add_address_args(parser)
+    # ZZZ - cloaked contests are enabled at cast_ballot time
+    #    parser.add_argument('-k', "--cloak", action="store_true",
+    #                            help="if possible provide a cloaked ballot offset")
+    parser.add_argument(
+        "--demo_mode",
+        action="store_true",
+        help="set demo mode to automatically cast random ballots",
+    )
+    parser.add_argument(
+        "--blank_ballot",
+        help="overrides an address - specifies the specific blank ballot",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbosity",
+        type=int,
+        default=3,
+        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
+    )
+    parser.add_argument(
+        "-n",
+        "--printonly",
+        action="store_true",
+        help="will printonly and not write to disk (def=True)",
+    )
+    return parser.parse_args(safe_args)
 
 
 # pylint: disable=duplicate-code
@@ -36,9 +94,9 @@ def main():
     source file.
     """
 
-    # do it
-    cbo = CastBallotOperation(sys.argv[1:])
-    cbo.run()
+    args = parse_arguments(sys.argv[1:])
+    op = CastBallotOperation(args)
+    op.run()
 
 
 # If called directly via this file

--- a/src/vtp/cli/cast_ballot.py
+++ b/src/vtp/cli/cast_ballot.py
@@ -27,6 +27,7 @@ import argparse
 import sys
 
 # Local imports
+from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.cast_ballot_operation import CastBallotOperation
 
@@ -55,7 +56,6 @@ blank ballot and allow a user to manually select choices or when in
 demo mode, cast_ballot.py will randominly select choices.
 """,
     )
-
     Arguments.add_address(parser)
     # ZZZ - cloaked contests are enabled at cast_ballot time
     #    parser.add_argument('-k', "--cloak", action="store_true",
@@ -67,12 +67,16 @@ demo mode, cast_ballot.py will randominly select choices.
     )
     parser.add_argument(
         "--blank_ballot",
+        default="",
         help="overrides an address - specifies the specific blank ballot",
     )
     Arguments.add_verbosity(parser)
     Arguments.add_print_only(parser)
 
-    return parser.parse_args(safe_args)
+    args = parser.parse_args(safe_args)
+    address_args, parsed = Arguments.separate_addresses(args)
+    parsed["address"] = Address(**address_args)
+    return parsed
 
 
 # pylint: disable=duplicate-code
@@ -80,7 +84,7 @@ def main():
     """Entry point for 'cast-ballot'."""
 
     args = parse_arguments(sys.argv[1:])
-    op = CastBallotOperation(args)
+    op = CastBallotOperation(**args)
     op.run()
 
 

--- a/src/vtp/cli/cast_ballot.py
+++ b/src/vtp/cli/cast_ballot.py
@@ -26,11 +26,11 @@ Run with '--help' for usage information.
 import argparse
 import sys
 
-# Local imports
-from vtp.core.address import Address
+# Project imports
 from vtp.core.common import Common
 from vtp.ops.cast_ballot_operation import CastBallotOperation
 
+# Local imports
 from ._arguments import Arguments
 
 

--- a/src/vtp/cli/cast_ballot.py
+++ b/src/vtp/cli/cast_ballot.py
@@ -27,7 +27,6 @@ import argparse
 import sys
 
 # Local imports
-from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.cast_ballot_operation import CastBallotOperation
 
@@ -57,7 +56,7 @@ demo mode, cast_ballot.py will randominly select choices.
 """,
     )
 
-    Address.add_address_args(parser)
+    Arguments.add_address(parser)
     # ZZZ - cloaked contests are enabled at cast_ballot time
     #    parser.add_argument('-k', "--cloak", action="store_true",
     #                            help="if possible provide a cloaked ballot offset")

--- a/src/vtp/cli/cast_ballot.py
+++ b/src/vtp/cli/cast_ballot.py
@@ -31,6 +31,8 @@ from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.cast_ballot_operation import CastBallotOperation
 
+from ._arguments import Arguments
+
 
 def parse_arguments(argv):
     """
@@ -68,19 +70,9 @@ demo mode, cast_ballot.py will randominly select choices.
         "--blank_ballot",
         help="overrides an address - specifies the specific blank ballot",
     )
-    parser.add_argument(
-        "-v",
-        "--verbosity",
-        type=int,
-        default=3,
-        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-    )
-    parser.add_argument(
-        "-n",
-        "--printonly",
-        action="store_true",
-        help="will printonly and not write to disk (def=True)",
-    )
+    Arguments.add_verbosity(parser)
+    Arguments.add_print_only(parser)
+
     return parser.parse_args(safe_args)
 
 

--- a/src/vtp/cli/create_blank_ballot.py
+++ b/src/vtp/cli/create_blank_ballot.py
@@ -56,10 +56,9 @@ supplied address.
     Arguments.add_verbosity(parser)
     Arguments.add_print_only(parser)
 
-    args = parser.parse_args(safe_args)
-    address_args, parsed = Arguments.separate_addresses(args)
-    parsed["address"] = Address(**address_args)
-    return parsed
+    parsed_args = Arguments.parse_arguments(parser, safe_args)
+    # Validation, if any is needed, goes here
+    return parsed_args
 
 
 def main():

--- a/src/vtp/cli/create_blank_ballot.py
+++ b/src/vtp/cli/create_blank_ballot.py
@@ -33,6 +33,8 @@ from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.create_blank_ballot_operation import CreateBlankBallotOperation
 
+from ._arguments import Arguments
+
 
 def parse_arguments(argv):
     safe_args = Common.cast_thing_to_list(argv)
@@ -44,6 +46,7 @@ VTP ElectionData git tree and create a blank ballot based on the
 supplied address.
 """,
     )
+
     Address.add_address_args(parser)
     parser.add_argument(
         "-l",
@@ -51,19 +54,9 @@ supplied address.
         default="en",
         help="will print the ballot in the specified language",
     )
-    parser.add_argument(
-        "-v",
-        "--verbosity",
-        type=int,
-        default=3,
-        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-    )
-    parser.add_argument(
-        "-n",
-        "--printonly",
-        action="store_true",
-        help="will printonly and not write to disk (def=True)",
-    )
+    Arguments.add_verbosity(parser)
+    Arguments.add_print_only(parser)
+
     return parser.parse_args(safe_args)
 
 

--- a/src/vtp/cli/create_blank_ballot.py
+++ b/src/vtp/cli/create_blank_ballot.py
@@ -29,7 +29,6 @@ import argparse
 import sys
 
 # Local imports
-from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.create_blank_ballot_operation import CreateBlankBallotOperation
 
@@ -47,7 +46,7 @@ supplied address.
 """,
     )
 
-    Address.add_address_args(parser)
+    Arguments.add_address(parser)
     parser.add_argument(
         "-l",
         "--language",

--- a/src/vtp/cli/create_blank_ballot.py
+++ b/src/vtp/cli/create_blank_ballot.py
@@ -29,6 +29,7 @@ import argparse
 import sys
 
 # Local imports
+from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.create_blank_ballot_operation import CreateBlankBallotOperation
 
@@ -45,7 +46,6 @@ VTP ElectionData git tree and create a blank ballot based on the
 supplied address.
 """,
     )
-
     Arguments.add_address(parser)
     parser.add_argument(
         "-l",
@@ -56,14 +56,17 @@ supplied address.
     Arguments.add_verbosity(parser)
     Arguments.add_print_only(parser)
 
-    return parser.parse_args(safe_args)
+    args = parser.parse_args(safe_args)
+    address_args, parsed = Arguments.separate_addresses(args)
+    parsed["address"] = Address(**address_args)
+    return parsed
 
 
 def main():
     """Entry point for 'accept-ballot'."""
 
     args = parse_arguments(sys.argv[1:])
-    op = CreateBlankBallotOperation(args)
+    op = CreateBlankBallotOperation(**args)
     op.run()
 
 

--- a/src/vtp/cli/create_blank_ballot.py
+++ b/src/vtp/cli/create_blank_ballot.py
@@ -28,11 +28,11 @@ See 'docs/tech/executable-overview.md' for the context in which this file was cr
 import argparse
 import sys
 
-# Local imports
-from vtp.core.address import Address
+# Project imports
 from vtp.core.common import Common
 from vtp.ops.create_blank_ballot_operation import CreateBlankBallotOperation
 
+# Local imports
 from ._arguments import Arguments
 
 

--- a/src/vtp/cli/create_blank_ballot.py
+++ b/src/vtp/cli/create_blank_ballot.py
@@ -17,12 +17,11 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""create_blank_ballot.py - command line level test script to automatically cast a ballot.
+"""Command line script to automatically cast a ballot.
 
-See './create_blank_ballot.py -h' for usage information.
+Run with '--help' for usage information.
 
-See ../../docs/tech/executable-overview.md for the context in which this file was created.
-
+See 'docs/tech/executable-overview.md' for the context in which this file was created.
 """
 
 # Standard imports
@@ -36,8 +35,6 @@ from vtp.ops.create_blank_ballot_operation import CreateBlankBallotOperation
 
 
 def parse_arguments(argv):
-    """Parse arguments from a command line or from the constructor"""
-
     safe_args = Common.cast_thing_to_list(argv)
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -71,13 +68,7 @@ supplied address.
 
 
 def main():
-    """
-    Called via a python local install entrypoint or by running this
-    file.  Simply wraps the scripts constructor and calls the run
-    method.  See the script's help output or read the
-    vtp.ops.create_blank_ballot_operation.py (argparse) description in
-    the source file.
-    """
+    """Entry point for 'accept-ballot'."""
 
     args = parse_arguments(sys.argv[1:])
     op = CreateBlankBallotOperation(args)

--- a/src/vtp/cli/create_blank_ballot.py
+++ b/src/vtp/cli/create_blank_ballot.py
@@ -26,15 +26,50 @@ See ../../docs/tech/executable-overview.md for the context in which this file wa
 """
 
 # Standard imports
+import argparse
 import sys
 
 # Local imports
+from vtp.core.address import Address
+from vtp.core.common import Common
 from vtp.ops.create_blank_ballot_operation import CreateBlankBallotOperation
 
 
-################
-# main
-################
+def parse_arguments(argv):
+    """Parse arguments from a command line or from the constructor"""
+
+    safe_args = Common.cast_thing_to_list(argv)
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""
+Will parse all the config and address_map yaml files in the current
+VTP ElectionData git tree and create a blank ballot based on the
+supplied address.
+""",
+    )
+    Address.add_address_args(parser)
+    parser.add_argument(
+        "-l",
+        "--language",
+        default="en",
+        help="will print the ballot in the specified language",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbosity",
+        type=int,
+        default=3,
+        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
+    )
+    parser.add_argument(
+        "-n",
+        "--printonly",
+        action="store_true",
+        help="will printonly and not write to disk (def=True)",
+    )
+    return parser.parse_args(safe_args)
+
+
 def main():
     """
     Called via a python local install entrypoint or by running this
@@ -44,13 +79,11 @@ def main():
     the source file.
     """
 
-    # do it
-    cbbo = CreateBlankBallotOperation(sys.argv[1:])
-    cbbo.run()
+    args = parse_arguments(sys.argv[1:])
+    op = CreateBlankBallotOperation(args)
+    op.run()
 
 
 # If called directly via this file
 if __name__ == "__main__":
     main()
-
-# EOF

--- a/src/vtp/cli/generate_all_blank_ballots.py
+++ b/src/vtp/cli/generate_all_blank_ballots.py
@@ -45,11 +45,12 @@ ballots and generate them.  They will be placed in the town's
 blank-ballots subdir.
 """,
     )
-
     Arguments.add_verbosity(parser)
     Arguments.add_print_only(parser)
 
-    return parser.parse_args(safe_args)
+    args = parser.parse_args(safe_args)
+    args = vars(args)
+    return args
 
 
 def main():
@@ -62,7 +63,7 @@ def main():
     """
 
     args = parse_arguments(sys.argv[1:])
-    op = GenerateAllBlankBallotsOperation(args)
+    op = GenerateAllBlankBallotsOperation(**args)
     op.run()
 
 

--- a/src/vtp/cli/generate_all_blank_ballots.py
+++ b/src/vtp/cli/generate_all_blank_ballots.py
@@ -48,9 +48,9 @@ blank-ballots subdir.
     Arguments.add_verbosity(parser)
     Arguments.add_print_only(parser)
 
-    args = parser.parse_args(safe_args)
-    args = vars(args)
-    return args
+    parsed_args = Arguments.parse_arguments(parser, safe_args)
+    # Validation, if any is needed, goes here
+    return parsed_args
 
 
 def main():

--- a/src/vtp/cli/generate_all_blank_ballots.py
+++ b/src/vtp/cli/generate_all_blank_ballots.py
@@ -27,7 +27,6 @@ import argparse
 import sys
 
 # Local import
-from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.generate_all_blank_ballots_operation import (
     GenerateAllBlankBallotsOperation,

--- a/src/vtp/cli/generate_all_blank_ballots.py
+++ b/src/vtp/cli/generate_all_blank_ballots.py
@@ -17,9 +17,9 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""generate_all_blank_ballots.py - generate all possible blank ballots
+"""Command line script to generate all possible blank ballots.
 
-See 'generate_all_blank_ballots.py -h' for usage information.
+Run with '--help' for usage information.
 """
 
 # Standard imports
@@ -35,8 +35,6 @@ from vtp.ops.generate_all_blank_ballots_operation import (
 
 
 def parse_arguments(argv):
-    """Parse arguments from a command line or from the constructor"""
-
     safe_args = Common.cast_thing_to_list(argv)
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/src/vtp/cli/generate_all_blank_ballots.py
+++ b/src/vtp/cli/generate_all_blank_ballots.py
@@ -23,17 +23,47 @@ See 'generate_all_blank_ballots.py -h' for usage information.
 """
 
 # Standard imports
+import argparse
 import sys
 
 # Local import
+from vtp.core.address import Address
+from vtp.core.common import Common
 from vtp.ops.generate_all_blank_ballots_operation import (
     GenerateAllBlankBallotsOperation,
 )
 
 
-################
-# main
-################
+def parse_arguments(argv):
+    """Parse arguments from a command line or from the constructor"""
+
+    safe_args = Common.cast_thing_to_list(argv)
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""
+Will crawl the ElectionData tree and determine all possible blank
+ballots and generate them.  They will be placed in the town's
+blank-ballots subdir.
+""",
+    )
+
+    parser.add_argument(
+        "-v",
+        "--verbosity",
+        type=int,
+        default=3,
+        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
+    )
+    parser.add_argument(
+        "-n",
+        "--printonly",
+        action="store_true",
+        help="will printonly and not write to disk (def=True)",
+    )
+
+    return parser.parse_args(safe_args)
+
+
 def main():
     """
     Called via a python local install entrypoint or by running this
@@ -43,13 +73,11 @@ def main():
     description in the source file.
     """
 
-    # do it
-    gabbo = GenerateAllBlankBallotsOperation(sys.argv[1:])
-    gabbo.run()
+    args = parse_arguments(sys.argv[1:])
+    op = GenerateAllBlankBallotsOperation(args)
+    op.run()
 
 
 # If called directly via this file
 if __name__ == "__main__":
     main()
-
-# EOF

--- a/src/vtp/cli/generate_all_blank_ballots.py
+++ b/src/vtp/cli/generate_all_blank_ballots.py
@@ -33,6 +33,8 @@ from vtp.ops.generate_all_blank_ballots_operation import (
     GenerateAllBlankBallotsOperation,
 )
 
+from ._arguments import Arguments
+
 
 def parse_arguments(argv):
     safe_args = Common.cast_thing_to_list(argv)
@@ -45,19 +47,8 @@ blank-ballots subdir.
 """,
     )
 
-    parser.add_argument(
-        "-v",
-        "--verbosity",
-        type=int,
-        default=3,
-        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-    )
-    parser.add_argument(
-        "-n",
-        "--printonly",
-        action="store_true",
-        help="will printonly and not write to disk (def=True)",
-    )
+    Arguments.add_verbosity(parser)
+    Arguments.add_print_only(parser)
 
     return parser.parse_args(safe_args)
 

--- a/src/vtp/cli/generate_all_blank_ballots.py
+++ b/src/vtp/cli/generate_all_blank_ballots.py
@@ -26,12 +26,13 @@ Run with '--help' for usage information.
 import argparse
 import sys
 
-# Local import
+# Project imports
 from vtp.core.common import Common
 from vtp.ops.generate_all_blank_ballots_operation import (
     GenerateAllBlankBallotsOperation,
 )
 
+# Local imports
 from ._arguments import Arguments
 
 

--- a/src/vtp/cli/merge_contests.py
+++ b/src/vtp/cli/merge_contests.py
@@ -33,6 +33,8 @@ from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.merge_contests_operation import MergeContestsOperation
 
+from ._arguments import Arguments
+
 
 def parse_arguments(argv):
     safe_args = Common.cast_thing_to_list(argv)
@@ -51,13 +53,7 @@ branch.
     parser.add_argument(
         "-b", "--branch", default="", help="specify a specific branch to merge"
     )
-    parser.add_argument(
-        "-m",
-        "--minimum_cast_cache",
-        type=int,
-        default=100,
-        help="the minimum number of cast ballots required prior to merging (def=100)",
-    )
+    Arguments.add_minimum_cast_cache(parser)
     parser.add_argument(
         "-f",
         "--flush",
@@ -70,19 +66,9 @@ branch.
         action="store_true",
         help="will merge remote branches instead of local branches",
     )
-    parser.add_argument(
-        "-v",
-        "--verbosity",
-        type=int,
-        default=3,
-        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-    )
-    parser.add_argument(
-        "-n",
-        "--printonly",
-        action="store_true",
-        help="will printonly and not write to disk (def=True)",
-    )
+    Arguments.add_verbosity(parser)
+    Arguments.add_print_only(parser)
+
     return parser.parse_args(safe_args)
 
 

--- a/src/vtp/cli/merge_contests.py
+++ b/src/vtp/cli/merge_contests.py
@@ -29,7 +29,6 @@ import argparse
 import sys
 
 # Local imports
-from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.merge_contests_operation import MergeContestsOperation
 

--- a/src/vtp/cli/merge_contests.py
+++ b/src/vtp/cli/merge_contests.py
@@ -68,7 +68,9 @@ branch.
     Arguments.add_verbosity(parser)
     Arguments.add_print_only(parser)
 
-    return parser.parse_args(safe_args)
+    args = parser.parse_args(safe_args)
+    args = vars(args)
+    return args
 
 
 # pylint: disable=duplicate-code
@@ -76,7 +78,7 @@ def main():
     """Entry point for 'merge-contests'."""
 
     args = parse_arguments(sys.argv[1:])
-    op = MergeContestsOperation(args)
+    op = MergeContestsOperation(**args)
     op.run()
 
 

--- a/src/vtp/cli/merge_contests.py
+++ b/src/vtp/cli/merge_contests.py
@@ -25,12 +25,70 @@ See 'merge_contests.py -h' for usage information.
 """
 
 # Standard imports
+import argparse
 import sys
 
 # Local imports
+from vtp.core.address import Address
+from vtp.core.common import Common
 from vtp.ops.merge_contests_operation import MergeContestsOperation
 
 
+def parse_arguments(argv):
+    """Parse arguments from a command line or from the constructor"""
+
+    safe_args = Common.cast_thing_to_list(argv)
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""
+Will run the git based workflow on a VTP server node so to merge
+pending CVR contest branches into the main git branch.
+
+If there are less then the prerequisite number of already cast
+contests, a warning will be printed/logged but no error will be
+raised.  Supplying -f will flush all remaining contests to the main
+branch.
+""",
+    )
+    parser.add_argument(
+        "-b", "--branch", default="", help="specify a specific branch to merge"
+    )
+    parser.add_argument(
+        "-m",
+        "--minimum_cast_cache",
+        type=int,
+        default=100,
+        help="the minimum number of cast ballots required prior to merging (def=100)",
+    )
+    parser.add_argument(
+        "-f",
+        "--flush",
+        action="store_true",
+        help="will flush the remaining unmerged contest branches",
+    )
+    parser.add_argument(
+        "-r",
+        "--remote",
+        action="store_true",
+        help="will merge remote branches instead of local branches",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbosity",
+        type=int,
+        default=3,
+        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
+    )
+    parser.add_argument(
+        "-n",
+        "--printonly",
+        action="store_true",
+        help="will printonly and not write to disk (def=True)",
+    )
+    return parser.parse_args(safe_args)
+
+
+# pylint: disable=duplicate-code
 def main():
     """
     Called via a python local install entrypoint or by running this
@@ -40,9 +98,9 @@ def main():
     source file.
     """
 
-    # do it
-    mco = MergeContestsOperation(sys.argv[1:])
-    mco.run()
+    args = parse_arguments(sys.argv[1:])
+    op = MergeContestsOperation(args)
+    op.run()
 
 
 # If called directly via this file

--- a/src/vtp/cli/merge_contests.py
+++ b/src/vtp/cli/merge_contests.py
@@ -68,9 +68,9 @@ branch.
     Arguments.add_verbosity(parser)
     Arguments.add_print_only(parser)
 
-    args = parser.parse_args(safe_args)
-    args = vars(args)
-    return args
+    parsed_args = Arguments.parse_arguments(parser, safe_args)
+    # Validation, if any is needed, goes here
+    return parsed_args
 
 
 # pylint: disable=duplicate-code

--- a/src/vtp/cli/merge_contests.py
+++ b/src/vtp/cli/merge_contests.py
@@ -17,11 +17,11 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""
-Command line level script to merge CVR contest
-branches into the main branch
+"""Command line script to merge CVR contest.
 
-See 'merge_contests.py -h' for usage information.
+Branches into the main branch.
+
+Run with '--help' for usage information.
 """
 
 # Standard imports
@@ -35,8 +35,6 @@ from vtp.ops.merge_contests_operation import MergeContestsOperation
 
 
 def parse_arguments(argv):
-    """Parse arguments from a command line or from the constructor"""
-
     safe_args = Common.cast_thing_to_list(argv)
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -90,13 +88,7 @@ branch.
 
 # pylint: disable=duplicate-code
 def main():
-    """
-    Called via a python local install entrypoint or by running this
-    file.  Simply wraps the scripts constructor and calls the run
-    method.  See the script's help output or read the
-    vtp.ops.merge_contests_operation.py (argparse) description in the
-    source file.
-    """
+    """Entry point for 'merge-contests'."""
 
     args = parse_arguments(sys.argv[1:])
     op = MergeContestsOperation(args)

--- a/src/vtp/cli/merge_contests.py
+++ b/src/vtp/cli/merge_contests.py
@@ -28,10 +28,11 @@ Run with '--help' for usage information.
 import argparse
 import sys
 
-# Local imports
+# Project imports
 from vtp.core.common import Common
 from vtp.ops.merge_contests_operation import MergeContestsOperation
 
+# Local imports
 from ._arguments import Arguments
 
 

--- a/src/vtp/cli/run_mock_election.py
+++ b/src/vtp/cli/run_mock_election.py
@@ -24,12 +24,126 @@ See 'run_mock_election.py -h' for usage information.
 """
 
 # Standard imports
+import argparse
 import sys
 
 # Local import
+from vtp.core.address import Address
+from vtp.core.common import Common
 from vtp.ops.run_mock_election_operation import RunMockElectionOperation
 
 
+def parse_arguments(argv):
+    """Parse arguments from a command line or from the constructor"""
+
+    safe_args = Common.cast_thing_to_list(argv)
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""
+Will run a mock election with N ballots across the available blank
+ballots found in the ElectionData.
+
+One basic idea is to run this in different windows, one per VTP
+scanner.  The scanner is nominally associated with a town (as
+configured).
+
+When "-d scanner" is supplied, run_mock_election.py will randomly
+cast and scan ballots.
+
+When "-d server" is supplied, run_mock_election.py will
+synchronously run the merge_contests.py program which will once
+every 10 seconds.  Note that nominally 100 contgests need to have
+been pushed for merge_contests.py to merge in a contest into the
+main branch without the --flush_mode option.
+
+If "-d both" is supplied, run_mock_election.py will run a single
+scanner N iterations while also calling the server function.  If
+--flush_mode is set to 1 or 2, run_mock_election.py will then
+flush the ballot cache before printing the tallies and exiting.
+
+By default run_mock_election.py will loop over all available blank
+ballots found withint the ElectionData tree.  However, either a
+specific blank ballot or an address can be specified to limit the
+mock to a single ballot N times.
+""",
+    )
+
+    Address.add_address_args(parser)
+    parser.add_argument(
+        "--blank_ballot",
+        help="overrides an address - specifies the specific blank ballot",
+    )
+    parser.add_argument(
+        "-d",
+        "--device",
+        default="",
+        help="specify a specific VC local device (scanner or server or both) to mock",
+    )
+    parser.add_argument(
+        "-m",
+        "--minimum_cast_cache",
+        type=int,
+        default=100,
+        help="the minimum number of cast ballots required prior to merging (def=100)",
+    )
+    # Note - the black formatter will by default break the help
+    # line below into two lines via a '()', which breaks the
+    # parser.add_argument.  It is python.
+    #
+    # fmt: off
+    parser.add_argument(
+        "-f",
+        "--flush_mode",
+        type=int,
+        default=0,
+        help="will either not flush (0 - default), flush on exit (1), or flush on each iteration (2)",
+    )
+    # fmt: on
+    parser.add_argument(
+        "-i",
+        "--iterations",
+        type=int,
+        default=10,
+        help="the number of unique blank ballots for the scanner app to cast (def=10)",
+    )
+    parser.add_argument(
+        "-u",
+        "--duration",
+        type=int,
+        default=10,
+        help="the number of minutes for the server app to run (def=10)",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbosity",
+        type=int,
+        default=3,
+        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
+    )
+    parser.add_argument(
+        "-n",
+        "--printonly",
+        action="store_true",
+        help="will printonly and not write to disk (def=True)",
+    )
+
+    parsed_args = parser.parse_args(safe_args)
+
+    # Validate required args
+    if parsed_args.device not in ["scanner", "server", "both"]:
+        raise ValueError(
+            "The --device parameter only accepts 'device' or 'server' "
+            f"or 'both' - ({parsed_args.device}) was suppllied."
+        )
+    if parsed_args.flush_mode not in [0, 1, 2]:
+        raise ValueError(
+            "The value of flush_mode must be either 0, 1, or 2"
+            f" - {parsed_args.flush_mode} was supplied."
+        )
+    return parsed_args
+
+
+# pylint: disable=duplicate-code
 def main():
     """
     Called via a python local install entrypoint or by running this
@@ -39,9 +153,9 @@ def main():
     source file.
     """
 
-    # do it
-    rmeo = RunMockElectionOperation(sys.argv[1:])
-    rmeo.run()
+    args = parse_arguments(sys.argv[1:])
+    op = RunMockElectionOperation(args)
+    op.run()
 
 
 # If called directly via this file

--- a/src/vtp/cli/run_mock_election.py
+++ b/src/vtp/cli/run_mock_election.py
@@ -17,10 +17,9 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""
-Command line level script to run either a VTP ballot scanner or tabulator app
+"""Command line script to run either a VTP ballot scanner or tabulator app.
 
-See 'run_mock_election.py -h' for usage information.
+Run with '--help' for usage information.
 """
 
 # Standard imports
@@ -34,8 +33,6 @@ from vtp.ops.run_mock_election_operation import RunMockElectionOperation
 
 
 def parse_arguments(argv):
-    """Parse arguments from a command line or from the constructor"""
-
     safe_args = Common.cast_thing_to_list(argv)
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -145,13 +142,7 @@ mock to a single ballot N times.
 
 # pylint: disable=duplicate-code
 def main():
-    """
-    Called via a python local install entrypoint or by running this
-    file.  Simply wraps the scripts constructor and calls the run
-    method.  See the script's help output or read the
-    vtp.ops.run_mock_election_operation.py (argparse) description in the
-    source file.
-    """
+    """Entry point for 'run-mock-elections'."""
 
     args = parse_arguments(sys.argv[1:])
     op = RunMockElectionOperation(args)

--- a/src/vtp/cli/run_mock_election.py
+++ b/src/vtp/cli/run_mock_election.py
@@ -27,7 +27,6 @@ import argparse
 import sys
 
 # Local import
-from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.run_mock_election_operation import RunMockElectionOperation
 
@@ -67,7 +66,7 @@ mock to a single ballot N times.
 """,
     )
 
-    Address.add_address_args(parser)
+    Arguments.add_address(parser)
     parser.add_argument(
         "--blank_ballot",
         help="overrides an address - specifies the specific blank ballot",

--- a/src/vtp/cli/run_mock_election.py
+++ b/src/vtp/cli/run_mock_election.py
@@ -31,6 +31,8 @@ from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.run_mock_election_operation import RunMockElectionOperation
 
+from ._arguments import Arguments
+
 
 def parse_arguments(argv):
     safe_args = Common.cast_thing_to_list(argv)
@@ -76,13 +78,7 @@ mock to a single ballot N times.
         default="",
         help="specify a specific VC local device (scanner or server or both) to mock",
     )
-    parser.add_argument(
-        "-m",
-        "--minimum_cast_cache",
-        type=int,
-        default=100,
-        help="the minimum number of cast ballots required prior to merging (def=100)",
-    )
+    Arguments.add_minimum_cast_cache(parser)
     # Note - the black formatter will by default break the help
     # line below into two lines via a '()', which breaks the
     # parser.add_argument.  It is python.
@@ -110,23 +106,13 @@ mock to a single ballot N times.
         default=10,
         help="the number of minutes for the server app to run (def=10)",
     )
-    parser.add_argument(
-        "-v",
-        "--verbosity",
-        type=int,
-        default=3,
-        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-    )
-    parser.add_argument(
-        "-n",
-        "--printonly",
-        action="store_true",
-        help="will printonly and not write to disk (def=True)",
-    )
+    Arguments.add_verbosity(parser)
+    Arguments.add_print_only(parser)
 
     parsed_args = parser.parse_args(safe_args)
 
     # Validate required args
+
     if parsed_args.device not in ["scanner", "server", "both"]:
         raise ValueError(
             "The --device parameter only accepts 'device' or 'server' "

--- a/src/vtp/cli/run_mock_election.py
+++ b/src/vtp/cli/run_mock_election.py
@@ -27,6 +27,7 @@ import argparse
 import sys
 
 # Local import
+from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.run_mock_election_operation import RunMockElectionOperation
 
@@ -116,7 +117,10 @@ mock to a single ballot N times.
             "The value of flush_mode must be either 0, 1, or 2"
             f" - {parsed_args.flush_mode} was supplied."
         )
-    return parsed_args
+
+    address_args, parsed = Arguments.separate_addresses(parsed_args)
+    parsed["address"] = Address(**address_args)
+    return parsed
 
 
 # pylint: disable=duplicate-code
@@ -124,7 +128,7 @@ def main():
     """Entry point for 'run-mock-elections'."""
 
     args = parse_arguments(sys.argv[1:])
-    op = RunMockElectionOperation(args)
+    op = RunMockElectionOperation(**args)
     op.run()
 
 

--- a/src/vtp/cli/run_mock_election.py
+++ b/src/vtp/cli/run_mock_election.py
@@ -78,11 +78,6 @@ mock to a single ballot N times.
         help="specify a specific VC local device (scanner or server or both) to mock",
     )
     Arguments.add_minimum_cast_cache(parser)
-    # Note - the black formatter will by default break the help
-    # line below into two lines via a '()', which breaks the
-    # parser.add_argument.  It is python.
-    #
-    # fmt: off
     parser.add_argument(
         "-f",
         "--flush_mode",
@@ -90,7 +85,6 @@ mock to a single ballot N times.
         default=0,
         help="will either not flush (0 - default), flush on exit (1), or flush on each iteration (2)",
     )
-    # fmt: on
     parser.add_argument(
         "-i",
         "--iterations",

--- a/src/vtp/cli/run_mock_election.py
+++ b/src/vtp/cli/run_mock_election.py
@@ -26,11 +26,11 @@ Run with '--help' for usage information.
 import argparse
 import sys
 
-# Local import
-from vtp.core.address import Address
+# Project imports
 from vtp.core.common import Common
 from vtp.ops.run_mock_election_operation import RunMockElectionOperation
 
+# Local imports
 from ._arguments import Arguments
 
 

--- a/src/vtp/cli/run_mock_election.py
+++ b/src/vtp/cli/run_mock_election.py
@@ -103,24 +103,21 @@ mock to a single ballot N times.
     Arguments.add_verbosity(parser)
     Arguments.add_print_only(parser)
 
-    parsed_args = parser.parse_args(safe_args)
+    parsed_args = Arguments.parse_arguments(parser, safe_args)
 
-    # Validate required args
-
-    if parsed_args.device not in ["scanner", "server", "both"]:
+    # Validation
+    if parsed_args["device"] not in ["scanner", "server", "both"]:
         raise ValueError(
             "The --device parameter only accepts 'device' or 'server' "
-            f"or 'both' - ({parsed_args.device}) was suppllied."
+            f"or 'both' - ({parsed_args['device']}) was supplied."
         )
-    if parsed_args.flush_mode not in [0, 1, 2]:
+    if parsed_args["flush_mode"] not in [0, 1, 2]:
         raise ValueError(
             "The value of flush_mode must be either 0, 1, or 2"
-            f" - {parsed_args.flush_mode} was supplied."
+            f" - {parsed_args['flush_mode']} was supplied."
         )
 
-    address_args, parsed = Arguments.separate_addresses(parsed_args)
-    parsed["address"] = Address(**address_args)
-    return parsed
+    return parsed_args
 
 
 # pylint: disable=duplicate-code

--- a/src/vtp/cli/setup_vtp_demo.py
+++ b/src/vtp/cli/setup_vtp_demo.py
@@ -17,11 +17,11 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""
-Command line level script script set up a VTP demo.  Can also set up
-individual GUID based ballot-stores and return the GUID
+"""Command line script set up a VTP demo.
 
-See 'setup_vtp_demo -h' for usage information.
+Can also set up individual GUID based ballot-stores and return the GUID.
+
+Run with '--help' for usage information.
 """
 
 # Standard imports
@@ -35,8 +35,6 @@ from vtp.ops.setup_vtp_demo_operation import SetupVtpDemoOperation
 
 
 def parse_arguments(argv):
-    """Parse arguments from a command line or from the constructor"""
-
     safe_args = Common.cast_thing_to_list(argv)
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -118,13 +116,7 @@ the GUID.
 
 
 def main():
-    """
-    Called via a python local install entrypoint or by running this
-    file.  Simply wraps the scripts constructor and calls the run
-    method.  See the script's help output or read the
-    vtp.ops.setup_vtp_demo_operation.py (argparse) description in the
-    source file.
-    """
+    """Entry point for 'setup-vtp-demo'."""
 
     args = parse_arguments(sys.argv[1:])
     op = SetupVtpDemoOperation(args)

--- a/src/vtp/cli/setup_vtp_demo.py
+++ b/src/vtp/cli/setup_vtp_demo.py
@@ -26,6 +26,7 @@ Run with '--help' for usage information.
 
 # Standard imports
 import argparse
+import os
 import sys
 
 # Local imports
@@ -110,7 +111,7 @@ def main():
     """Entry point for 'setup-vtp-demo'."""
 
     args = parse_arguments(sys.argv[1:])
-    op = SetupVtpDemoOperation(args)
+    op = SetupVtpDemoOperation(**args)
     guid = op.run()
     if isinstance(guid, str):
         print(guid)

--- a/src/vtp/cli/setup_vtp_demo.py
+++ b/src/vtp/cli/setup_vtp_demo.py
@@ -29,10 +29,11 @@ import argparse
 import os
 import sys
 
-# Local imports
+# Project imports
 from vtp.core.common import Common, Globals
 from vtp.ops.setup_vtp_demo_operation import SetupVtpDemoOperation
 
+# Local imports
 from ._arguments import Arguments
 
 

--- a/src/vtp/cli/setup_vtp_demo.py
+++ b/src/vtp/cli/setup_vtp_demo.py
@@ -82,28 +82,30 @@ the GUID.
     Arguments.add_verbosity(parser)
     Arguments.add_print_only(parser)
 
-    parsed_args = parser.parse_args(safe_args)
-    # Validate required args
-    if parsed_args.scanners < 1 or parsed_args.scanners > 16:
+    parsed_args = Arguments.parse_arguments(parser, safe_args)
+
+    # Validation
+    if parsed_args["scanners"] < 1 or parsed_args["scanners"] > 16:
         raise ValueError(
             "The demo needs at least one TVP scanner app "
             "and arbitrarily limits a demo to 16."
         )
     # Check the root of the demo
-    if not os.path.isdir(parsed_args.location):
+    if not os.path.isdir(parsed_args["location"]):
         raise FileNotFoundError(
-            f"The root demo folder, {parsed_args.location}, does not exit.  "
+            f"The root demo folder, {parsed_args['location']}, does not exit.  "
             "It needs to pre-exist - please manually create it."
         )
     test_dir = os.path.join(
-        parsed_args.location, Globals.get("TABULATION_SERVER_DIRNAME")
+        parsed_args["location"], Globals.get("TABULATION_SERVER_DIRNAME")
     )
-    if parsed_args.guid_client_store and not os.path.isdir(test_dir):
+    if parsed_args["guid_client_store"] and not os.path.isdir(test_dir):
         raise FileNotFoundError(
             f"The tabulation server workspace ({test_dir}) does not exit.  "
             "It needs to pre-exist and is created when setup-vtp-demo is executed "
             "in setup mode (without the -g switch)."
         )
+
     return parsed_args
 
 

--- a/src/vtp/cli/setup_vtp_demo.py
+++ b/src/vtp/cli/setup_vtp_demo.py
@@ -24,11 +24,97 @@ individual GUID based ballot-stores and return the GUID
 See 'setup_vtp_demo -h' for usage information.
 """
 
-# Global imports
+# Standard imports
+import argparse
 import sys
 
 # Local imports
+from vtp.core.address import Address
+from vtp.core.common import Common, Globals
 from vtp.ops.setup_vtp_demo_operation import SetupVtpDemoOperation
+
+
+def parse_arguments(argv):
+    """Parse arguments from a command line or from the constructor"""
+
+    safe_args = Common.cast_thing_to_list(argv)
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""
+Will leverage this current git repository (VoteTrackerPlus) and the
+associated ElectionData repo(s) to nominally create in
+/opt/VoteTrackerPlus (the default) a demo election with 4 mock ballot
+scanner apps and one tabulation server app. The initial demo idea is
+to have three scanners scanning random ballots while one scanner is
+used interactively.
+
+All five apps run in separate git workspaces that are clones of the
+same ElectionData repo(s). The (4) mock scanner app clones are located
+in one folder, the one tabulation server is located in another, and
+the FastAPI clients are located in a third. The FastAPI clients are
+separated by a GUID based subdirectory similar to the native Git
+storage idiom.
+
+If the --guid_client_store option is set, instead of setting up the
+demo this script will create a new GUID based FASTapi clone and return
+the GUID.
+""",
+    )
+    parser.add_argument(
+        "-s",
+        "--scanners",
+        type=int,
+        default=4,
+        help="specify a number of scanner app instances (def=4)",
+    )
+    parser.add_argument(
+        "-g",
+        "--guid_client_store",
+        action="store_true",
+        help="if set will create a single GUID based ballot-store and return the GUID",
+    )
+    parser.add_argument(
+        "-l",
+        "--location",
+        default="/opt/VoteTrackerPlus/demo.01",
+        help="specify the location of VTP demo (def=/opt/VoteTrackerPlus/demo.01)",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbosity",
+        type=int,
+        default=3,
+        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
+    )
+    parser.add_argument(
+        "-n",
+        "--printonly",
+        action="store_true",
+        help="will printonly and not write to disk (def=True)",
+    )
+    parsed_args = parser.parse_args(safe_args)
+    # Validate required args
+    if parsed_args.scanners < 1 or parsed_args.scanners > 16:
+        raise ValueError(
+            "The demo needs at least one TVP scanner app "
+            "and arbitrarily limits a demo to 16."
+        )
+    # Check the root of the demo
+    if not os.path.isdir(parsed_args.location):
+        raise FileNotFoundError(
+            f"The root demo folder, {parsed_args.location}, does not exit.  "
+            "It needs to pre-exist - please manually create it."
+        )
+    test_dir = os.path.join(
+        parsed_args.location, Globals.get("TABULATION_SERVER_DIRNAME")
+    )
+    if parsed_args.guid_client_store and not os.path.isdir(test_dir):
+        raise FileNotFoundError(
+            f"The tabulation server workspace ({test_dir}) does not exit.  "
+            "It needs to pre-exist and is created when setup-vtp-demo is executed "
+            "in setup mode (without the -g switch)."
+        )
+    return parsed_args
 
 
 def main():
@@ -40,9 +126,9 @@ def main():
     source file.
     """
 
-    # do it
-    svdo = SetupVtpDemoOperation(sys.argv[1:])
-    guid = svdo.run()
+    args = parse_arguments(sys.argv[1:])
+    op = SetupVtpDemoOperation(args)
+    guid = op.run()
     if isinstance(guid, str):
         print(guid)
 

--- a/src/vtp/cli/setup_vtp_demo.py
+++ b/src/vtp/cli/setup_vtp_demo.py
@@ -33,6 +33,8 @@ from vtp.core.address import Address
 from vtp.core.common import Common, Globals
 from vtp.ops.setup_vtp_demo_operation import SetupVtpDemoOperation
 
+from ._arguments import Arguments
+
 
 def parse_arguments(argv):
     safe_args = Common.cast_thing_to_list(argv)
@@ -77,19 +79,9 @@ the GUID.
         default="/opt/VoteTrackerPlus/demo.01",
         help="specify the location of VTP demo (def=/opt/VoteTrackerPlus/demo.01)",
     )
-    parser.add_argument(
-        "-v",
-        "--verbosity",
-        type=int,
-        default=3,
-        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-    )
-    parser.add_argument(
-        "-n",
-        "--printonly",
-        action="store_true",
-        help="will printonly and not write to disk (def=True)",
-    )
+    Arguments.add_verbosity(parser)
+    Arguments.add_print_only(parser)
+
     parsed_args = parser.parse_args(safe_args)
     # Validate required args
     if parsed_args.scanners < 1 or parsed_args.scanners > 16:

--- a/src/vtp/cli/setup_vtp_demo.py
+++ b/src/vtp/cli/setup_vtp_demo.py
@@ -29,7 +29,6 @@ import argparse
 import sys
 
 # Local imports
-from vtp.core.address import Address
 from vtp.core.common import Common, Globals
 from vtp.ops.setup_vtp_demo_operation import SetupVtpDemoOperation
 

--- a/src/vtp/cli/show_contest.py
+++ b/src/vtp/cli/show_contest.py
@@ -24,6 +24,7 @@ Run with '--help' for usage information.
 
 # Standard imports
 import argparse
+import re
 import sys
 
 # Local imports
@@ -41,7 +42,7 @@ def parse_arguments(argv):
 will print the CVRs (Cast Vote Records) for the supplied contest(s)
 """,
     )
-
+    # TODO: Change to use nargs="+" to allow space separated arguments?
     parser.add_argument(
         "-c",
         "--contest-check",
@@ -60,7 +61,10 @@ will print the CVRs (Cast Vote Records) for the supplied contest(s)
             "The contest_check parameter only accepts a comma separated (no spaces) "
             "list of contest checks/digests to track."
         )
-    return parsed_args
+
+    args = parser.parse_args(safe_args)
+    args = vars(args)
+    return args
 
 
 # pylint: disable=duplicate-code
@@ -68,7 +72,7 @@ def main():
     """Entry point for 'show-contest'."""
 
     args = parse_arguments(sys.argv[1:])
-    op = ShowContestsOperation(args)
+    op = ShowContestsOperation(**args)
     op.run()
 
 

--- a/src/vtp/cli/show_contest.py
+++ b/src/vtp/cli/show_contest.py
@@ -27,7 +27,7 @@ import argparse
 import re
 import sys
 
-# Local imports
+# Project imports
 from vtp.core.common import Common
 from vtp.ops.show_contests_operation import ShowContestsOperation
 

--- a/src/vtp/cli/show_contest.py
+++ b/src/vtp/cli/show_contest.py
@@ -31,6 +31,8 @@ from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.show_contests_operation import ShowContestsOperation
 
+from ._arguments import Arguments
+
 
 def parse_arguments(argv):
     safe_args = Common.cast_thing_to_list(argv)
@@ -46,19 +48,9 @@ will print the CVRs (Cast Vote Records) for the supplied contest(s)
         "--contest-check",
         help="a comma separate list of contests digests to validate/display",
     )
-    parser.add_argument(
-        "-v",
-        "--verbosity",
-        type=int,
-        default=3,
-        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-    )
-    parser.add_argument(
-        "-n",
-        "--printonly",
-        action="store_true",
-        help="will printonly and not write to disk (def=True)",
-    )
+    Arguments.add_verbosity(parser)
+    Arguments.add_print_only(parser)
+
     parsed_args = parser.parse_args(safe_args)
 
     # Validate required args

--- a/src/vtp/cli/show_contest.py
+++ b/src/vtp/cli/show_contest.py
@@ -23,12 +23,58 @@ See 'show_contest.py -h' for usage information.
 """
 
 # Standard imports
+import argparse
 import sys
 
 # Local imports
+from vtp.core.address import Address
+from vtp.core.common import Common
 from vtp.ops.show_contests_operation import ShowContestsOperation
 
 
+def parse_arguments(argv):
+    """Parse arguments from a command line or from the constructor"""
+
+    safe_args = Common.cast_thing_to_list(argv)
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""
+will print the CVRs (Cast Vote Records) for the supplied contest(s)
+""",
+    )
+
+    parser.add_argument(
+        "-c",
+        "--contest-check",
+        help="a comma separate list of contests digests to validate/display",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbosity",
+        type=int,
+        default=3,
+        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
+    )
+    parser.add_argument(
+        "-n",
+        "--printonly",
+        action="store_true",
+        help="will printonly and not write to disk (def=True)",
+    )
+    parsed_args = parser.parse_args(safe_args)
+
+    # Validate required args
+    if not parsed_args.contest_check:
+        raise ValueError("The contest check is required")
+    if not bool(re.match("^[0-9a-f,]", parsed_args.contest_check)):
+        raise ValueError(
+            "The contest_check parameter only accepts a comma separated (no spaces) "
+            "list of contest checks/digests to track."
+        )
+    return parsed_args
+
+
+# pylint: disable=duplicate-code
 def main():
     """
     Called via a python local install entrypoint or by running this
@@ -38,9 +84,9 @@ def main():
     source file.
     """
 
-    # do it
-    sco = ShowContestsOperation(sys.argv[1:])
-    sco.run()
+    args = parse_arguments(sys.argv[1:])
+    op = ShowContestsOperation(args)
+    op.run()
 
 
 # If called directly via this file

--- a/src/vtp/cli/show_contest.py
+++ b/src/vtp/cli/show_contest.py
@@ -51,20 +51,18 @@ will print the CVRs (Cast Vote Records) for the supplied contest(s)
     Arguments.add_verbosity(parser)
     Arguments.add_print_only(parser)
 
-    parsed_args = parser.parse_args(safe_args)
+    parsed_args = Arguments.parse_arguments(parser, safe_args)
 
-    # Validate required args
-    if not parsed_args.contest_check:
+    # Validation
+    if not parsed_args["contest_check"]:
         raise ValueError("The contest check is required")
-    if not bool(re.match("^[0-9a-f,]", parsed_args.contest_check)):
+    if not bool(re.match("^[0-9a-f,]", parsed_args["contest_check"])):
         raise ValueError(
             "The contest_check parameter only accepts a comma separated (no spaces) "
             "list of contest checks/digests to track."
         )
 
-    args = parser.parse_args(safe_args)
-    args = vars(args)
-    return args
+    return parsed_args
 
 
 # pylint: disable=duplicate-code

--- a/src/vtp/cli/show_contest.py
+++ b/src/vtp/cli/show_contest.py
@@ -17,9 +17,9 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""Command line level script to automatically cast a ballot.
+"""Command line script to automatically cast a ballot.
 
-See 'show_contest.py -h' for usage information.
+Run with '--help' for usage information.
 """
 
 # Standard imports
@@ -33,8 +33,6 @@ from vtp.ops.show_contests_operation import ShowContestsOperation
 
 
 def parse_arguments(argv):
-    """Parse arguments from a command line or from the constructor"""
-
     safe_args = Common.cast_thing_to_list(argv)
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -76,13 +74,7 @@ will print the CVRs (Cast Vote Records) for the supplied contest(s)
 
 # pylint: disable=duplicate-code
 def main():
-    """
-    Called via a python local install entrypoint or by running this
-    file.  Simply wraps the scripts constructor and calls the run
-    method.  See the script's help output or read the
-    vtp.ops.show_contests_operation.py (argparse) description in the
-    source file.
-    """
+    """Entry point for 'show-contest'."""
 
     args = parse_arguments(sys.argv[1:])
     op = ShowContestsOperation(args)

--- a/src/vtp/cli/show_contest.py
+++ b/src/vtp/cli/show_contest.py
@@ -27,7 +27,6 @@ import argparse
 import sys
 
 # Local imports
-from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.show_contests_operation import ShowContestsOperation
 

--- a/src/vtp/cli/tally_contests.py
+++ b/src/vtp/cli/tally_contests.py
@@ -24,6 +24,7 @@ Run with '--help' for usage information.
 
 # Standard imports
 import argparse
+import re
 import sys
 
 # Local imports
@@ -53,13 +54,13 @@ Also note that the current implementation does not yet support
 tallying across git submodules/repos.
 """,
     )
-
     parser.add_argument(
         "-c",
         "--contest_uid",
         default="",
         help="limit the tally to a specific contest uid",
     )
+    # TODO: Change to use nargs="+" to allow space separated arguments?
     parser.add_argument(
         "-t",
         "--track_contests",
@@ -87,14 +88,17 @@ tallying across git submodules/repos.
         parsed_args.track_contests = parsed_args.track_contests.split(",")
     else:
         parsed_args.track_contests = []
-    return parsed_args
+
+    args = parser.parse_args(safe_args)
+    args = vars(args)
+    return args
 
 
 def main():
     """Entry point for 'tally-contests'."""
 
     args = parse_arguments(sys.argv[1:])
-    op = TallyContestsOperation(args)
+    op = TallyContestsOperation(**args)
     op.run()
 
 

--- a/src/vtp/cli/tally_contests.py
+++ b/src/vtp/cli/tally_contests.py
@@ -27,10 +27,11 @@ import argparse
 import re
 import sys
 
-# Local imports
+# Project imports
 from vtp.core.common import Common
 from vtp.ops.tally_contests_operation import TallyContestsOperation
 
+# Local imports
 from ._arguments import Arguments
 
 

--- a/src/vtp/cli/tally_contests.py
+++ b/src/vtp/cli/tally_contests.py
@@ -76,22 +76,20 @@ tallying across git submodules/repos.
     Arguments.add_verbosity(parser)
     # Arguments.add_print_only(parser)
 
-    parsed_args = parser.parse_args(safe_args)
+    parsed_args = Arguments.parse_arguments(parser, safe_args)
 
-    # Validate required args
-    if parsed_args.track_contests:
-        if not bool(re.match("^[0-9a-f,]", parsed_args.track_contests)):
+    # Validation
+    if parsed_args["track_contests"]:
+        if not bool(re.match("^[0-9a-f,]", parsed_args["track_contests"])):
             raise ValueError(
                 "The track_contests parameter only accepts a comma separated (no spaces) "
                 "list of contest checks/digests to track."
             )
-        parsed_args.track_contests = parsed_args.track_contests.split(",")
+        parsed_args["track_contests"] = parsed_args["track_contests"].split(",")
     else:
-        parsed_args.track_contests = []
+        parsed_args["track_contests"] = []
 
-    args = parser.parse_args(safe_args)
-    args = vars(args)
-    return args
+    return parsed_args
 
 
 def main():

--- a/src/vtp/cli/tally_contests.py
+++ b/src/vtp/cli/tally_contests.py
@@ -27,7 +27,6 @@ import argparse
 import sys
 
 # Local imports
-from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.tally_contests_operation import TallyContestsOperation
 

--- a/src/vtp/cli/tally_contests.py
+++ b/src/vtp/cli/tally_contests.py
@@ -17,11 +17,9 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""
-tally_contests.py - command line level script to tally the contests of
-a election.
+"""Command line script to tally the contests of a election.
 
-See 'tally_contests.py -h' for usage information.
+Run with '--help' for usage information.
 """
 
 # Standard imports
@@ -35,8 +33,6 @@ from vtp.ops.tally_contests_operation import TallyContestsOperation
 
 
 def parse_arguments(argv):
-    """Parse arguments from a command line or from the constructor"""
-
     safe_args = Common.cast_thing_to_list(argv)
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -101,13 +97,7 @@ tallying across git submodules/repos.
 
 
 def main():
-    """
-    Called via a python local install entrypoint or by running this
-    file.  Simply wraps the scripts constructor and calls the run
-    method.  See the script's help output or read the
-    vtp.ops.tally_contests_operation.py (argparse) description in the
-    source file.
-    """
+    """Entry point for 'tally-contests'."""
 
     args = parse_arguments(sys.argv[1:])
     op = TallyContestsOperation(args)

--- a/src/vtp/cli/tally_contests.py
+++ b/src/vtp/cli/tally_contests.py
@@ -31,6 +31,8 @@ from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.tally_contests_operation import TallyContestsOperation
 
+from ._arguments import Arguments
+
 
 def parse_arguments(argv):
     safe_args = Common.cast_thing_to_list(argv)
@@ -71,15 +73,8 @@ tallying across git submodules/repos.
         action="store_true",
         help="Before tallying the votes, pull the ElectionData repo",
     )
-    parser.add_argument(
-        "-v",
-        "--verbosity",
-        type=int,
-        default=3,
-        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-    )
-    #    parser.add_argument("-n", "--printonly", action="store_true",
-    #                            help="will printonly and not write to disk (def=True)")
+    Arguments.add_verbosity(parser)
+    # Arguments.add_print_only(parser)
 
     parsed_args = parser.parse_args(safe_args)
 

--- a/src/vtp/cli/tally_contests.py
+++ b/src/vtp/cli/tally_contests.py
@@ -24,11 +24,80 @@ a election.
 See 'tally_contests.py -h' for usage information.
 """
 
-# Global imports
+# Standard imports
+import argparse
 import sys
 
 # Local imports
+from vtp.core.address import Address
+from vtp.core.common import Common
 from vtp.ops.tally_contests_operation import TallyContestsOperation
+
+
+def parse_arguments(argv):
+    """Parse arguments from a command line or from the constructor"""
+
+    safe_args = Common.cast_thing_to_list(argv)
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""
+Will tally all the contests so far merged to the main branch and
+report the results.  The results are computed on a voting center basis
+(git submodule) basis.
+
+Note - the current implementation relies on git submodules (individual
+git repos) to break up the tally data of an election.  If there is
+only one git repository and the election is large, then a potentiallu
+large amount of memory will be used in executing the tallies.  One
+short term fix for this is to limit the number of contests being
+tallied.
+
+Also note that the current implementation does not yet support
+tallying across git submodules/repos.
+""",
+    )
+
+    parser.add_argument(
+        "-c",
+        "--contest_uid",
+        default="",
+        help="limit the tally to a specific contest uid",
+    )
+    parser.add_argument(
+        "-t",
+        "--track_contests",
+        default="",
+        help="a comma separated list of contests checks to track",
+    )
+    parser.add_argument(
+        "-x",
+        "--do_not_pull",
+        action="store_true",
+        help="Before tallying the votes, pull the ElectionData repo",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbosity",
+        type=int,
+        default=3,
+        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
+    )
+    #    parser.add_argument("-n", "--printonly", action="store_true",
+    #                            help="will printonly and not write to disk (def=True)")
+
+    parsed_args = parser.parse_args(safe_args)
+
+    # Validate required args
+    if parsed_args.track_contests:
+        if not bool(re.match("^[0-9a-f,]", parsed_args.track_contests)):
+            raise ValueError(
+                "The track_contests parameter only accepts a comma separated (no spaces) "
+                "list of contest checks/digests to track."
+            )
+        parsed_args.track_contests = parsed_args.track_contests.split(",")
+    else:
+        parsed_args.track_contests = []
+    return parsed_args
 
 
 def main():
@@ -40,9 +109,9 @@ def main():
     source file.
     """
 
-    # do it
-    tco = TallyContestsOperation(sys.argv[1:])
-    tco.run()
+    args = parse_arguments(sys.argv[1:])
+    op = TallyContestsOperation(args)
+    op.run()
 
 
 # If called directly via this file

--- a/src/vtp/cli/verify_ballot_receipt.py
+++ b/src/vtp/cli/verify_ballot_receipt.py
@@ -29,6 +29,7 @@ import argparse
 import sys
 
 # Local imports
+from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.verify_ballot_receipt_operation import VerifyBallotReceiptOperation
 
@@ -53,7 +54,6 @@ Can also optionally print the ballot's CVRs when a specific ballot
 check row is provided.
 """,
     )
-
     Arguments.add_address(parser, True)
     parser.add_argument(
         "-f",
@@ -82,21 +82,24 @@ check row is provided.
     Arguments.add_verbosity(parser)
     # Arguments.add_print_only(parser)
 
-    parsed_args = parser.parse_args(safe_args)
+    args = parser.parse_args(safe_args)
 
     # Validate required args
-    if not (parsed_args.receipt_file or (parsed_args.state and parsed_args.town)):
+    if not (args.receipt_file or (args.state and args.town)):
         raise ValueError(
             "Either an explicit or implicit (via an address) receipt file must be provided"
         )
-    return parsed_args
+
+    address_args, parsed = Arguments.separate_addresses(args)
+    parsed["address"] = Address(generic_address = True, **address_args)
+    return parsed
 
 
 def main():
     """Entry point for 'verify-ballot-receipt'."""
 
     args = parse_arguments(sys.argv[1:])
-    op = VerifyBallotReceiptOperation(args)
+    op = VerifyBallotReceiptOperation(**args)
     op.run()
 
 

--- a/src/vtp/cli/verify_ballot_receipt.py
+++ b/src/vtp/cli/verify_ballot_receipt.py
@@ -29,7 +29,6 @@ import argparse
 import sys
 
 # Local imports
-from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.verify_ballot_receipt_operation import VerifyBallotReceiptOperation
 
@@ -55,7 +54,7 @@ check row is provided.
 """,
     )
 
-    Address.add_address_args(parser, True)
+    Arguments.add_address(parser, True)
     parser.add_argument(
         "-f",
         "--receipt_file",

--- a/src/vtp/cli/verify_ballot_receipt.py
+++ b/src/vtp/cli/verify_ballot_receipt.py
@@ -91,7 +91,7 @@ check row is provided.
         )
 
     address_args, parsed = Arguments.separate_addresses(args)
-    parsed["address"] = Address(generic_address = True, **address_args)
+    parsed["address"] = Address(generic_address=True, **address_args)
     return parsed
 
 

--- a/src/vtp/cli/verify_ballot_receipt.py
+++ b/src/vtp/cli/verify_ballot_receipt.py
@@ -54,7 +54,8 @@ Can also optionally print the ballot's CVRs when a specific ballot
 check row is provided.
 """,
     )
-    Arguments.add_address(parser, True)
+    generic_address = True
+    Arguments.add_address(parser, generic_address)
     parser.add_argument(
         "-f",
         "--receipt_file",
@@ -82,17 +83,21 @@ check row is provided.
     Arguments.add_verbosity(parser)
     # Arguments.add_print_only(parser)
 
-    args = parser.parse_args(safe_args)
+    parsed_args = Arguments.parse_arguments(parser, safe_args, generic_address)
 
-    # Validate required args
-    if not (args.receipt_file or (args.state and args.town)):
+    # Validation
+    if not (
+        parsed_args["receipt_file"]
+        or (
+            parsed_args["address"].address["state"]
+            and parsed_args["address"].address["town"]
+        )
+    ):
         raise ValueError(
             "Either an explicit or implicit (via an address) receipt file must be provided"
         )
 
-    address_args, parsed = Arguments.separate_addresses(args)
-    parsed["address"] = Address(generic_address=True, **address_args)
-    return parsed
+    return parsed_args
 
 
 def main():

--- a/src/vtp/cli/verify_ballot_receipt.py
+++ b/src/vtp/cli/verify_ballot_receipt.py
@@ -33,6 +33,8 @@ from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.verify_ballot_receipt_operation import VerifyBallotReceiptOperation
 
+from ._arguments import Arguments
+
 
 def parse_arguments(argv):
     safe_args = Common.cast_thing_to_list(argv)
@@ -78,15 +80,8 @@ check row is provided.
         action="store_true",
         help="Before tallying the votes, pull the ElectionData repo",
     )
-    parser.add_argument(
-        "-v",
-        "--verbosity",
-        type=int,
-        default=3,
-        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-    )
-    #    parser.add_argument("-n", "--printonly", action="store_true",
-    #                            help="will printonly and not write to disk (def=True)")
+    Arguments.add_verbosity(parser)
+    # Arguments.add_print_only(parser)
 
     parsed_args = parser.parse_args(safe_args)
 

--- a/src/vtp/cli/verify_ballot_receipt.py
+++ b/src/vtp/cli/verify_ballot_receipt.py
@@ -17,10 +17,11 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""
-Command line level script to verify a voters ballot receipt.  Supports several interesting options.
+"""Command line script to verify a voter's ballot receipt.
 
-See 'verify_ballot_receipt.py -h' for usage information.
+Supports several interesting options.
+
+Run with '--help' for usage information.
 """
 
 # Standard imports
@@ -34,8 +35,6 @@ from vtp.ops.verify_ballot_receipt_operation import VerifyBallotReceiptOperation
 
 
 def parse_arguments(argv):
-    """Parse arguments from a command line or from the constructor"""
-
     safe_args = Common.cast_thing_to_list(argv)
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -100,13 +99,7 @@ check row is provided.
 
 
 def main():
-    """
-    Called via a python local install entrypoint or by running this
-    file.  Simply wraps the scripts constructor and calls the run
-    method.  See the script's help output or read the
-    vtp.ops.verify_ballot_receipt_operation.py (argparse) description
-    in the source file.
-    """
+    """Entry point for 'verify-ballot-receipt'."""
 
     args = parse_arguments(sys.argv[1:])
     op = VerifyBallotReceiptOperation(args)

--- a/src/vtp/cli/verify_ballot_receipt.py
+++ b/src/vtp/cli/verify_ballot_receipt.py
@@ -28,11 +28,11 @@ Run with '--help' for usage information.
 import argparse
 import sys
 
-# Local imports
-from vtp.core.address import Address
+# Project imports
 from vtp.core.common import Common
 from vtp.ops.verify_ballot_receipt_operation import VerifyBallotReceiptOperation
 
+# Local imports
 from ._arguments import Arguments
 
 

--- a/src/vtp/cli/vote.py
+++ b/src/vtp/cli/vote.py
@@ -17,11 +17,11 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""
-vote.py - command line level script to allow an end voter to vote - it
-simply wraps a call to cast_ballot.py and accept_ballot.py.
+"""Command line script to allow an end voter to vote.
 
-See 'vote.py -h' for usage information.
+Simply wraps a call to cast_ballot.py and accept_ballot.py.
+
+Run with '--help' for usage information.
 """
 
 # Standard imports
@@ -35,8 +35,6 @@ from vtp.ops.vote_operation import VoteOperation
 
 
 def parse_arguments(argv):
-    """Parse arguments from a command line or from the constructor"""
-
     safe_args = Common.cast_thing_to_list(argv)
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -77,13 +75,7 @@ ballot is chosen.
 
 # pylint: disable=duplicate-code
 def main():
-    """
-    Called via a python local install entrypoint or by running this
-    file.  Simply wraps the scripts constructor and calls the run
-    method.  See the script's help output or read the
-    vtp.ops.vote_operation.py (argparse) description in the source
-    file.
-    """
+    """Entry point for 'vote'."""
 
     args = parse_arguments(sys.argv[1:])
     op = VoteOperation(args)

--- a/src/vtp/cli/vote.py
+++ b/src/vtp/cli/vote.py
@@ -28,8 +28,7 @@ Run with '--help' for usage information.
 import argparse
 import sys
 
-# Local imports
-from vtp.core.address import Address
+# Project imports
 from vtp.core.common import Common
 from vtp.ops.vote_operation import VoteOperation
 

--- a/src/vtp/cli/vote.py
+++ b/src/vtp/cli/vote.py
@@ -24,11 +24,55 @@ simply wraps a call to cast_ballot.py and accept_ballot.py.
 See 'vote.py -h' for usage information.
 """
 
-# Global imports
+# Standard imports
+import argparse
 import sys
 
 # Local imports
+from vtp.core.address import Address
+from vtp.core.common import Common
 from vtp.ops.vote_operation import VoteOperation
+
+
+def parse_arguments(argv):
+    """Parse arguments from a command line or from the constructor"""
+
+    safe_args = Common.cast_thing_to_list(argv)
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""
+Will interactively allow a voter to vote.  Internally it first calls
+cast_balloy.py followed by accept_ballot.py.  If a specific election
+address or a specific blank ballot is not specified, a random blank
+ballot is chosen.
+""",
+    )
+
+    Address.add_address_args(parser)
+    parser.add_argument(
+        "-m",
+        "--merge_contests",
+        action="store_true",
+        help="Will immediately merge the ballot contests (to main)",
+    )
+    parser.add_argument(
+        "--blank_ballot",
+        help="overrides an address - specifies the specific blank ballot",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbosity",
+        type=int,
+        default=3,
+        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
+    )
+    parser.add_argument(
+        "-n",
+        "--printonly",
+        action="store_true",
+        help="will printonly and not write to disk (def=True)",
+    )
+    return parser.parse_args(safe_args)
 
 
 # pylint: disable=duplicate-code
@@ -41,9 +85,9 @@ def main():
     file.
     """
 
-    # do it
-    vote_op = VoteOperation(sys.argv[1:])
-    vote_op.run()
+    args = parse_arguments(sys.argv[1:])
+    op = VoteOperation(args)
+    op.run()
 
 
 # If called directly via this file

--- a/src/vtp/cli/vote.py
+++ b/src/vtp/cli/vote.py
@@ -29,7 +29,6 @@ import argparse
 import sys
 
 # Local imports
-from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.vote_operation import VoteOperation
 
@@ -48,7 +47,7 @@ ballot is chosen.
 """,
     )
 
-    Address.add_address_args(parser)
+    Arguments.add_address(parser)
     Arguments.add_merge_contests(parser)
     parser.add_argument(
         "--blank_ballot",

--- a/src/vtp/cli/vote.py
+++ b/src/vtp/cli/vote.py
@@ -33,6 +33,8 @@ from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.vote_operation import VoteOperation
 
+from ._arguments import Arguments
+
 
 def parse_arguments(argv):
     safe_args = Common.cast_thing_to_list(argv)
@@ -47,29 +49,14 @@ ballot is chosen.
     )
 
     Address.add_address_args(parser)
-    parser.add_argument(
-        "-m",
-        "--merge_contests",
-        action="store_true",
-        help="Will immediately merge the ballot contests (to main)",
-    )
+    Arguments.add_merge_contests(parser)
     parser.add_argument(
         "--blank_ballot",
         help="overrides an address - specifies the specific blank ballot",
     )
-    parser.add_argument(
-        "-v",
-        "--verbosity",
-        type=int,
-        default=3,
-        help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-    )
-    parser.add_argument(
-        "-n",
-        "--printonly",
-        action="store_true",
-        help="will printonly and not write to disk (def=True)",
-    )
+    Arguments.add_verbosity(parser)
+    Arguments.add_print_only(parser)
+
     return parser.parse_args(safe_args)
 
 

--- a/src/vtp/cli/vote.py
+++ b/src/vtp/cli/vote.py
@@ -57,10 +57,9 @@ ballot is chosen.
     Arguments.add_verbosity(parser)
     Arguments.add_print_only(parser)
 
-    args = parser.parse_args(safe_args)
-    address_args, parsed = Arguments.separate_addresses(args)
-    parsed["address"] = Address(**address_args)
-    return parsed
+    parsed_args = Arguments.parse_arguments(parser, safe_args)
+    # Validation, if any is needed, goes here.
+    return parsed_args
 
 
 # pylint: disable=duplicate-code

--- a/src/vtp/cli/vote.py
+++ b/src/vtp/cli/vote.py
@@ -29,6 +29,7 @@ import argparse
 import sys
 
 # Local imports
+from vtp.core.address import Address
 from vtp.core.common import Common
 from vtp.ops.vote_operation import VoteOperation
 
@@ -56,7 +57,10 @@ ballot is chosen.
     Arguments.add_verbosity(parser)
     Arguments.add_print_only(parser)
 
-    return parser.parse_args(safe_args)
+    args = parser.parse_args(safe_args)
+    address_args, parsed = Arguments.separate_addresses(args)
+    parsed["address"] = Address(**address_args)
+    return parsed
 
 
 # pylint: disable=duplicate-code
@@ -64,7 +68,7 @@ def main():
     """Entry point for 'vote'."""
 
     args = parse_arguments(sys.argv[1:])
-    op = VoteOperation(args)
+    op = VoteOperation(**args)
     op.run()
 
 

--- a/src/vtp/core/address.py
+++ b/src/vtp/core/address.py
@@ -65,31 +65,6 @@ class Address:
         return Address(**my_args)
 
     @staticmethod
-    def add_address_args(parser, generic_address=False):
-        """Helper function to add standard address program switches to argparse"""
-        #        parser.add_argument('-c', "--csv",
-        #                                help="a comma separated address")
-        #        parser.add_argument('-r', "--street",
-        #                                help="the street/road field of an address, \
-        #                                in which case the address is the number")
-        #        parser.add_argument('-z', "--zipcode",
-        #                                help="the zipcode field of an address")
-        if not generic_address:
-            parser.add_argument(
-                "-a",
-                "--address",
-                help="the number and name of the \
-                                    street address (space separated)",
-            )
-            parser.add_argument(
-                "-b", "--substreet", help="the substreet field of an address"
-            )
-        parser.add_argument("-t", "--town", help="the town field of an address")
-        parser.add_argument(
-            "-s", "--state", help="the state/province field of an address"
-        )
-
-    @staticmethod
     def create_generic_address(config, subdir, ggos):
         """Will create/return a generic address nominally from the list
         of ggos

--- a/src/vtp/core/address.py
+++ b/src/vtp/core/address.py
@@ -123,6 +123,14 @@ class Address:
         return args
 
     @staticmethod
+    def has_address_arguments(args: dict):
+        """True if argument dictionary has any address fields."""
+        for key in Address._keys:
+            if key in args:
+                return True
+        return False
+
+    @staticmethod
     def create_generic_address(config, subdir, ggos):
         """Will create/return a generic address nominally from the list
         of ggos

--- a/src/vtp/ops/accept_ballot_operation.py
+++ b/src/vtp/ops/accept_ballot_operation.py
@@ -37,8 +37,13 @@ from .operation import Operation
 class AcceptBallotOperation(Operation):
     """Implementation of 'accept-ballot'."""
 
-    def __init__(self, address: Address, cast_ballot: str = "", merge_contests: str = "",
-                 **base_options):
+    def __init__(
+        self,
+        address: Address,
+        cast_ballot: str = "",
+        merge_contests: str = "",
+        **base_options,
+    ):
         """Create an accept ballot operation."""
         super().__init__(**base_options)
         self._address = address
@@ -315,9 +320,7 @@ class AcceptBallotOperation(Operation):
                     Globals.get("ROOT_ELECTION_DATA_SUBDIR"),
                 )
             ):
-                a_ballot.read_a_cast_ballot(
-                    "", the_election_config, self._cast_ballot
-                )
+                a_ballot.read_a_cast_ballot("", the_election_config, self._cast_ballot)
         else:
             self._address.map_ggos(the_election_config, skip_ggos=True)
             # Get the ballot for the specified address.  Note that reading

--- a/src/vtp/ops/accept_ballot_operation.py
+++ b/src/vtp/ops/accept_ballot_operation.py
@@ -25,7 +25,7 @@ import os
 import random
 import secrets
 
-# Local imports
+# Project imports
 from vtp.core.address import Address
 from vtp.core.ballot import Ballot, Contests
 from vtp.core.common import Common, Globals, Shellout

--- a/src/vtp/ops/accept_ballot_operation.py
+++ b/src/vtp/ops/accept_ballot_operation.py
@@ -17,11 +17,7 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""Library backend to command line level script to accept a ballot.
-
-See 'accept_ballot.py -h' for usage information.
-
-"""
+"""Logic of operation for accepting a ballot."""
 
 # Standard imports
 import logging
@@ -37,11 +33,7 @@ from vtp.core.election_config import ElectionConfig
 
 
 class AcceptBallotOperation:
-    """
-    A class to implememt the accept_ballot.py operation.  See the
-    cast-ballot help output or read the parse_argument argparse
-    description (immediately below this) in the source file.
-    """
+    """Implementation of 'accept-ballot'."""
 
     def __init__(self, args):
         """Only to module-ize the scripts and keep things simple and idiomatic."""
@@ -297,8 +289,6 @@ class AcceptBallotOperation:
 
     # pylint: disable=duplicate-code
     def run(self):
-        """Main function - see -h for more info"""
-
         # Configure logging
         Common.configure_logging(self.args.verbosity)
 

--- a/src/vtp/ops/cast_ballot_operation.py
+++ b/src/vtp/ops/cast_ballot_operation.py
@@ -17,11 +17,7 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""
-LIbrary backend to command line level test script to automatically cast a ballot.
-
-See 'cast_ballot.py -h' for usage information.
-"""
+"""Logic of operation for casting a ballot."""
 
 # Standard imports
 import logging
@@ -41,11 +37,7 @@ from vtp.core.election_config import ElectionConfig
 
 
 class CastBallotOperation:
-    """
-    A class to implememt the cast-ballot operation.  See the
-    cast-ballot help output or read the parse_argument argparse
-    description (immediately below this) in the source file.
-    """
+    """Implementation of 'cast-ballot'."""
 
     def __init__(self, args):
         """
@@ -226,8 +218,6 @@ class CastBallotOperation:
         return contests
 
     def run(self):
-        """Main function - see -h for more info"""
-
         # Configure logging
         Common.configure_logging(self.args.verbosity)
 

--- a/src/vtp/ops/cast_ballot_operation.py
+++ b/src/vtp/ops/cast_ballot_operation.py
@@ -29,7 +29,7 @@ import traceback
 
 import pyinputplus
 
-# Local imports
+# Project imports
 from vtp.core.address import Address
 from vtp.core.ballot import Ballot, BlankBallot, Contests
 from vtp.core.common import Common, Globals, Shellout

--- a/src/vtp/ops/create_blank_ballot_operation.py
+++ b/src/vtp/ops/create_blank_ballot_operation.py
@@ -17,10 +17,7 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""
-Library operation for command line level script set up a VTP demo
-See 'create_blank_ballot_operation.py -h' for usage information.
-"""
+"""Logic of operation for creating a blank ballot."""
 
 # Standard imports
 import logging
@@ -34,19 +31,13 @@ from vtp.core.election_config import ElectionConfig
 
 
 class CreateBlankBallotOperation:
-    """
-    A class to implememt the create-blank-ballot operation.  See the
-    create-blank-ballot help output or read the parse_argument argparse
-    description (immediately below this) in the source file.
-    """
+    """Implementation of 'create-blank-ballot'."""
 
     def __init__(self, args):
         """Only to module-ize the scripts and keep things simple and idiomatic."""
         self.args = args
 
     def run(self):
-        """Main function - see -h for more info"""
-
         # Configure logging
         Common.configure_logging(self.args.verbosity)
 

--- a/src/vtp/ops/create_blank_ballot_operation.py
+++ b/src/vtp/ops/create_blank_ballot_operation.py
@@ -23,7 +23,6 @@ See 'create_blank_ballot_operation.py -h' for usage information.
 """
 
 # Standard imports
-import argparse
 import logging
 import pprint
 
@@ -41,50 +40,15 @@ class CreateBlankBallotOperation:
     description (immediately below this) in the source file.
     """
 
-    @staticmethod
-    def parse_arguments(argv):
-        """Parse arguments from a command line or from the constructor"""
-
-        safe_args = Common.cast_thing_to_list(argv)
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.RawDescriptionHelpFormatter,
-            description="""
-    Will parse all the config and address_map yaml files in the current
-    VTP ElectionData git tree and create a blank ballot based on the
-    supplied address.
-    """,
-        )
-        Address.add_address_args(parser)
-        parser.add_argument(
-            "-l",
-            "--language",
-            default="en",
-            help="will print the ballot in the specified language",
-        )
-        parser.add_argument(
-            "-v",
-            "--verbosity",
-            type=int,
-            default=3,
-            help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-        )
-        parser.add_argument(
-            "-n",
-            "--printonly",
-            action="store_true",
-            help="will printonly and not write to disk (def=True)",
-        )
-        return parser.parse_args(safe_args)
-
-    def __init__(self, unparsed_args):
+    def __init__(self, args):
         """Only to module-ize the scripts and keep things simple and idiomatic."""
-        self.parsed_args = CreateBlankBallotOperation.parse_arguments(unparsed_args)
+        self.args = args
 
     def run(self):
         """Main function - see -h for more info"""
 
         # Configure logging
-        Common.configure_logging(self.parsed_args.verbosity)
+        Common.configure_logging(self.args.verbosity)
 
         # Create a VTP ElectionData object if one does not already exist
         the_election_config = ElectionConfig.configure_election()
@@ -99,7 +63,7 @@ class CreateBlankBallotOperation:
         # imported somehow. And all that comes later - for now just map an
         # address to a town.
         the_address = Address.create_address_from_args(
-            self.parsed_args, ["verbosity", "printonly", "language"]
+            self.args, ["verbosity", "printonly", "language"]
         )
         the_address.map_ggos(the_election_config)
 
@@ -126,11 +90,6 @@ class CreateBlankBallotOperation:
         )
 
         # Write it out
-        if not self.parsed_args.printonly:
+        if not self.args.printonly:
             ballot_file = the_ballot.write_blank_ballot(the_election_config)
             logging.info("Blank ballot file: %s", ballot_file)
-
-
-# End Of Class
-
-# EOF

--- a/src/vtp/ops/create_blank_ballot_operation.py
+++ b/src/vtp/ops/create_blank_ballot_operation.py
@@ -23,7 +23,7 @@
 import logging
 import pprint
 
-# Local import
+# Project imports
 from vtp.core.address import Address
 from vtp.core.ballot import BlankBallot
 from vtp.core.common import Common

--- a/src/vtp/ops/generate_all_blank_ballots_operation.py
+++ b/src/vtp/ops/generate_all_blank_ballots_operation.py
@@ -23,7 +23,6 @@ See 'generate_all_blank_ballots.py -h' for usage information.
 """
 
 # Standard imports
-import argparse
 import logging
 import os
 import pprint
@@ -43,47 +42,15 @@ class GenerateAllBlankBallotsOperation:
     description (immediately below this) in the source file.
     """
 
-    @staticmethod
-    def parse_arguments(argv):
-        """Parse arguments from a command line or from the constructor"""
-
-        safe_args = Common.cast_thing_to_list(argv)
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.RawDescriptionHelpFormatter,
-            description="""
-    Will crawl the ElectionData tree and determine all possible blank
-    ballots and generate them.  They will be placed in the town's
-    blank-ballots subdir.
-    """,
-        )
-
-        parser.add_argument(
-            "-v",
-            "--verbosity",
-            type=int,
-            default=3,
-            help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-        )
-        parser.add_argument(
-            "-n",
-            "--printonly",
-            action="store_true",
-            help="will printonly and not write to disk (def=True)",
-        )
-
-        return parser.parse_args(safe_args)
-
-    def __init__(self, unparsed_args):
+    def __init__(self, args):
         """Only to module-ize the scripts and keep things simple and idiomatic."""
-        self.parsed_args = GenerateAllBlankBallotsOperation.parse_arguments(
-            unparsed_args
-        )
+        self.args = args
 
     def run(self):
         """Main function - see -h for more info"""
 
         # Configure logging
-        Common.configure_logging(self.parsed_args.verbosity)
+        Common.configure_logging(self.args.verbosity)
 
         # Create a VTP ElectionData object if one does not already exist
         the_election_config = ElectionConfig.configure_election()
@@ -118,7 +85,7 @@ class GenerateAllBlankBallotsOperation:
                         pprint.pformat(generic_ballot.dict()),
                     )
                     # Write it out
-                    if self.parsed_args.printonly:
+                    if self.args.printonly:
                         ballot_file = the_election_config.gen_blank_ballot_location(
                             generic_address.active_ggos,
                             generic_address.ballot_subdir,
@@ -129,8 +96,3 @@ class GenerateAllBlankBallotsOperation:
                             the_election_config
                         )
                     logging.info("Blank ballot file: %s", ballot_file)
-
-
-# End Of Class
-
-# EOF

--- a/src/vtp/ops/generate_all_blank_ballots_operation.py
+++ b/src/vtp/ops/generate_all_blank_ballots_operation.py
@@ -17,10 +17,7 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""generate_all_blank_ballots.py - generate all possible blank ballots
-
-See 'generate_all_blank_ballots.py -h' for usage information.
-"""
+"""Logic of operation for generating blank ballots."""
 
 # Standard imports
 import logging
@@ -36,19 +33,13 @@ from vtp.core.election_config import ElectionConfig
 
 # pylint: disable=too-few-public-methods
 class GenerateAllBlankBallotsOperation:
-    """
-    A class to implememt the generate-all-blank-ballots operation.  See the
-    generate-all-blank-ballots help output or read the parse_argument argparse
-    description (immediately below this) in the source file.
-    """
+    """Implementation of 'generate-all-blank-ballots'."""
 
     def __init__(self, args):
         """Only to module-ize the scripts and keep things simple and idiomatic."""
         self.args = args
 
     def run(self):
-        """Main function - see -h for more info"""
-
         # Configure logging
         Common.configure_logging(self.args.verbosity)
 

--- a/src/vtp/ops/generate_all_blank_ballots_operation.py
+++ b/src/vtp/ops/generate_all_blank_ballots_operation.py
@@ -30,18 +30,22 @@ from vtp.core.ballot import BlankBallot
 from vtp.core.common import Common
 from vtp.core.election_config import ElectionConfig
 
+from .operation import Operation
 
 # pylint: disable=too-few-public-methods
-class GenerateAllBlankBallotsOperation:
+class GenerateAllBlankBallotsOperation(Operation):
     """Implementation of 'generate-all-blank-ballots'."""
 
-    def __init__(self, args):
-        """Only to module-ize the scripts and keep things simple and idiomatic."""
-        self.args = args
+    def __init__(
+        self,
+        **base_options,
+    ):
+        """Create a generate blank ballots operation."""
+        super().__init__(**base_options)
 
     def run(self):
         # Configure logging
-        Common.configure_logging(self.args.verbosity)
+        Common.configure_logging(self._verbosity)
 
         # Create a VTP ElectionData object if one does not already exist
         the_election_config = ElectionConfig.configure_election()
@@ -76,7 +80,7 @@ class GenerateAllBlankBallotsOperation:
                         pprint.pformat(generic_ballot.dict()),
                     )
                     # Write it out
-                    if self.args.printonly:
+                    if self._printonly:
                         ballot_file = the_election_config.gen_blank_ballot_location(
                             generic_address.active_ggos,
                             generic_address.ballot_subdir,

--- a/src/vtp/ops/generate_all_blank_ballots_operation.py
+++ b/src/vtp/ops/generate_all_blank_ballots_operation.py
@@ -24,7 +24,7 @@ import logging
 import os
 import pprint
 
-# Local import
+# Project imports
 from vtp.core.address import Address
 from vtp.core.ballot import BlankBallot
 from vtp.core.common import Common

--- a/src/vtp/ops/merge_contests_operation.py
+++ b/src/vtp/ops/merge_contests_operation.py
@@ -25,7 +25,7 @@ import os
 import random
 import re
 
-# Local import
+# Project imports
 from vtp.core.common import Common, Globals, Shellout
 from vtp.core.election_config import ElectionConfig
 

--- a/src/vtp/ops/merge_contests_operation.py
+++ b/src/vtp/ops/merge_contests_operation.py
@@ -17,12 +17,7 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""
-Library backend to command line level script to merge CVR contest
-branches into the main branch
-
-See './merge_contests.py -h' for usage information.
-"""
+"""Logic of operation for merging contests."""
 
 # Standard imports
 import logging
@@ -36,11 +31,7 @@ from vtp.core.election_config import ElectionConfig
 
 
 class MergeContestsOperation:
-    """
-    A class to implememt the merge-contests operation.  See the
-    merge-contests help output or read the parse_argument argparse
-    description (immediately below this) in the source file.
-    """
+    """Implementation of 'merge-contests'."""
 
     def __init__(self, args):
         """Only to module-ize the scripts and keep things simple and idiomatic."""
@@ -167,8 +158,6 @@ class MergeContestsOperation:
 
     # pylint: disable=duplicate-code
     def run(self):
-        """Main function - see -h for more info"""
-
         # Configure logging
         Common.configure_logging(self.args.verbosity)
 

--- a/src/vtp/ops/operation.py
+++ b/src/vtp/ops/operation.py
@@ -1,0 +1,25 @@
+#  VoteTrackerPlus
+#   Copyright (C) 2022 Sandy Currier
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, write to the Free Software Foundation, Inc.,
+#   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""Base class of operations."""
+
+
+class Operation:
+
+    def __init__(self, printonly: bool = True, verbosity: int = 3):
+        self._printonly = printonly
+        self._verbosity = verbosity

--- a/src/vtp/ops/operation.py
+++ b/src/vtp/ops/operation.py
@@ -19,7 +19,6 @@
 
 
 class Operation:
-
     def __init__(self, printonly: bool = True, verbosity: int = 3):
         self._printonly = printonly
         self._verbosity = verbosity

--- a/src/vtp/ops/run_mock_election_operation.py
+++ b/src/vtp/ops/run_mock_election_operation.py
@@ -24,18 +24,18 @@ import logging
 import os
 import time
 
-# Local libraries
+# Project imports
 from vtp.core.address import Address
 from vtp.core.ballot import Ballot
 from vtp.core.common import Common, Globals, Shellout
 from vtp.core.election_config import ElectionConfig
 
-# Script modules
+# Local imports
 from .operation import Operation
-from vtp.ops.accept_ballot_operation import AcceptBallotOperation
-from vtp.ops.cast_ballot_operation import CastBallotOperation
-from vtp.ops.merge_contests_operation import MergeContestsOperation
-from vtp.ops.tally_contests_operation import TallyContestsOperation
+from .accept_ballot_operation import AcceptBallotOperation
+from .cast_ballot_operation import CastBallotOperation
+from .merge_contests_operation import MergeContestsOperation
+from .tally_contests_operation import TallyContestsOperation
 
 
 class RunMockElectionOperation(Operation):

--- a/src/vtp/ops/run_mock_election_operation.py
+++ b/src/vtp/ops/run_mock_election_operation.py
@@ -17,12 +17,7 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""
-Library backend for command line level script to merge CVR contest
-branches into the main branch
-
-See 'run_mock_election.py -h' for usage information.
-"""
+"""Logic of operation for running a mock election."""
 
 # Standard imports
 import logging
@@ -43,11 +38,7 @@ from vtp.ops.tally_contests_operation import TallyContestsOperation
 
 
 class RunMockElectionOperation:
-    """
-    A class to implememt the run-mock-election operation.  See the
-    run-mock-election help output or read the parse_argument argparse
-    description (immediately below this) in the source file.
-    """
+    """Implementation of 'run-mock-election'."""
 
     def __init__(self, args):
         """Only to module-ize the scripts and keep things simple and idiomatic."""
@@ -258,7 +249,7 @@ class RunMockElectionOperation:
 
     # pylint: disable=duplicate-code
     def run(self):
-        """Main function - see -h for more info
+        """Run a mock election.
 
         Note - this is a serial synchronous mock election loop.  A
         parallel loop would have one VTP server git workspace somewhere

--- a/src/vtp/ops/setup_vtp_demo_operation.py
+++ b/src/vtp/ops/setup_vtp_demo_operation.py
@@ -23,7 +23,6 @@ See 'setup_vtp_demo -h' for usage information.
 """
 
 # Standard imports
-import argparse
 import logging
 import os
 import secrets
@@ -40,92 +39,9 @@ class SetupVtpDemoOperation:
     description (immediately below this) in the source file.
     """
 
-    @staticmethod
-    def parse_arguments(argv):
-        """Parse arguments from a command line or from the constructor"""
-
-        safe_args = Common.cast_thing_to_list(argv)
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.RawDescriptionHelpFormatter,
-            description="""
-Will leverage this current git repository (VoteTrackerPlus) and the
-associated ElectionData repo(s) to nominally create in
-/opt/VoteTrackerPlus (the default) a demo election with 4 mock ballot
-scanner apps and one tabulation server app. The initial demo idea is
-to have three scanners scanning random ballots while one scanner is
-used interactively.
-
-All five apps run in separate git workspaces that are clones of the
-same ElectionData repo(s). The (4) mock scanner app clones are located
-in one folder, the one tabulation server is located in another, and
-the FastAPI clients are located in a third. The FastAPI clients are
-separated by a GUID based subdirectory similar to the native Git
-storage idiom.
-
-If the --guid_client_store option is set, instead of setting up the
-demo this script will create a new GUID based FASTapi clone and return
-the GUID.
-""",
-        )
-        parser.add_argument(
-            "-s",
-            "--scanners",
-            type=int,
-            default=4,
-            help="specify a number of scanner app instances (def=4)",
-        )
-        parser.add_argument(
-            "-g",
-            "--guid_client_store",
-            action="store_true",
-            help="if set will create a single GUID based ballot-store and return the GUID",
-        )
-        parser.add_argument(
-            "-l",
-            "--location",
-            default="/opt/VoteTrackerPlus/demo.01",
-            help="specify the location of VTP demo (def=/opt/VoteTrackerPlus/demo.01)",
-        )
-        parser.add_argument(
-            "-v",
-            "--verbosity",
-            type=int,
-            default=3,
-            help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-        )
-        parser.add_argument(
-            "-n",
-            "--printonly",
-            action="store_true",
-            help="will printonly and not write to disk (def=True)",
-        )
-        parsed_args = parser.parse_args(safe_args)
-        # Validate required args
-        if parsed_args.scanners < 1 or parsed_args.scanners > 16:
-            raise ValueError(
-                "The demo needs at least one TVP scanner app "
-                "and arbitrarily limits a demo to 16."
-            )
-        # Check the root of the demo
-        if not os.path.isdir(parsed_args.location):
-            raise FileNotFoundError(
-                f"The root demo folder, {parsed_args.location}, does not exit.  "
-                "It needs to pre-exist - please manually create it."
-            )
-        test_dir = os.path.join(
-            parsed_args.location, Globals.get("TABULATION_SERVER_DIRNAME")
-        )
-        if parsed_args.guid_client_store and not os.path.isdir(test_dir):
-            raise FileNotFoundError(
-                f"The tabulation server workspace ({test_dir}) does not exit.  "
-                "It needs to pre-exist and is created when setup-vtp-demo is executed "
-                "in setup mode (without the -g switch)."
-            )
-        return parsed_args
-
-    def __init__(self, unparsed_args):
+    def __init__(self, args):
         """Only to module-ize the scripts and keep things simple and idiomatic."""
-        self.parsed_args = SetupVtpDemoOperation.parse_arguments(unparsed_args)
+        self.args = args
         # The absolute path to the local bare clone of the upstream
         # GitHub ElectionData remote repo
         self.tabulation_local_upstream_absdir = ""
@@ -134,7 +50,7 @@ the GUID.
         """Boilerplate"""
         return (
             "parsed_args="
-            + str(self.parsed_args)
+            + str(self.args)
             + "\ntabulation server="
             + self.tabulation_local_upstream_absdir
         )
@@ -149,12 +65,12 @@ the GUID.
         # local install idiom, the demo location no longer needs the
         # submodules to be cloned.
         for clone_dir in clone_dirs:
-            if not self.parsed_args.printonly:
+            if not self.args.printonly:
                 with Shellout.changed_cwd(clone_dir):
                     Shellout.run(
                         ["git", "clone", upstream_url],
-                        self.parsed_args.printonly,
-                        verbosity=self.parsed_args.verbosity,
+                        self.args.printonly,
+                        verbosity=self.args.verbosity,
                         check=True,
                     )
             else:
@@ -170,12 +86,12 @@ the GUID.
         # Note - mkdir raises an error if the directory exists. So
         # just try creating them.
         path1 = os.path.join(
-            self.parsed_args.location,
+            self.args.location,
             Globals.get("GUID_CLIENT_DIRNAME"),
             folder1,
         )
         path2 = os.path.join(path1, folder2)
-        if not self.parsed_args.printonly:
+        if not self.args.printonly:
             try:
                 logging.debug("creating (%s) if it does not exist", path1)
                 os.mkdir(path1)
@@ -215,15 +131,12 @@ the GUID.
         logging.debug("returning %s", guid)
         return guid
 
-    ################
-    # main
-    ################
     # pylint: disable=duplicate-code
     def run(self):
         """Main function - see -h for more info"""
 
         # Configure logging
-        Common.configure_logging(self.parsed_args.verbosity)
+        Common.configure_logging(self.args.verbosity)
 
         # Create a VTP ElectionData object if one does not already exist
         the_election_config = ElectionConfig.configure_election()
@@ -249,22 +162,22 @@ the GUID.
         # workspaces (client and server) will not have that suffix
         # (and not be bare).
         self.tabulation_local_upstream_absdir = os.path.join(
-            self.parsed_args.location,
+            self.args.location,
             Globals.get("TABULATION_SERVER_DIRNAME"),
             os.path.basename(election_data_remote_url),
         )
         # Need both the above and the dirname of the above
         bare_clone_path = os.path.dirname(self.tabulation_local_upstream_absdir)
         # When creating a GUID workspace ...
-        if self.parsed_args.guid_client_store:
+        if self.args.guid_client_store:
             return self.create_a_guid_workspace_folder()
 
         # ... or the initial setup of the non-GUID client and server workspaces
 
         # Only run if the directory is empty
-        if len(os.listdir(self.parsed_args.location)) != 0:
+        if len(os.listdir(self.args.location)) != 0:
             raise RuntimeError(
-                f"the directory ({self.parsed_args.location}) is not empty - "
+                f"the directory ({self.args.location}) is not empty - "
                 "setup-vtp-demo can only be run on an empty directory"
             )
 
@@ -274,19 +187,19 @@ the GUID.
             Globals.get("TABULATION_SERVER_DIRNAME"),
             Globals.get("MOCK_CLIENT_DIRNAME"),
         ]:
-            full_dir = os.path.join(self.parsed_args.location, subdir)
+            full_dir = os.path.join(self.args.location, subdir)
             if not os.path.isdir(full_dir):
                 logging.debug("creating (%s)", full_dir)
-                if not self.parsed_args.printonly:
+                if not self.args.printonly:
                     os.mkdir(full_dir)
 
         # Second clone the bare upstream remote GitHub ElectionData repo
-        if not self.parsed_args.printonly:
+        if not self.args.printonly:
             with Shellout.changed_cwd(bare_clone_path):
                 Shellout.run(
                     ["git", "clone", "--bare", election_data_remote_url],
-                    self.parsed_args.printonly,
-                    verbosity=self.parsed_args.verbosity,
+                    self.args.printonly,
+                    verbosity=self.args.verbosity,
                     check=True,
                 )
         else:
@@ -296,27 +209,27 @@ the GUID.
 
         # Third create the mock scanner client subdirs
         clone_dirs = []
-        for count in range(self.parsed_args.scanners):
+        for count in range(self.args.scanners):
             full_dir = os.path.join(
-                self.parsed_args.location,
+                self.args.location,
                 Globals.get("MOCK_CLIENT_DIRNAME"),
                 "scanner." + f"{count:02d}",
             )
             if not os.path.isdir(full_dir):
                 logging.debug("creating (%s)", full_dir)
-                if not self.parsed_args.printonly:
+                if not self.args.printonly:
                     os.mkdir(full_dir)
             clone_dirs.append(full_dir)
 
         # Fourth create the tabulation client subdir
         full_dir = os.path.join(
-            self.parsed_args.location,
+            self.args.location,
             Globals.get("MOCK_CLIENT_DIRNAME"),
             "server",
         )
         if not os.path.isdir(full_dir):
             logging.debug("creating (%s)", full_dir)
-            if not self.parsed_args.printonly:
+            if not self.args.printonly:
                 os.mkdir(full_dir)
         clone_dirs.append(full_dir)
 
@@ -327,8 +240,3 @@ the GUID.
 
         # return something
         return None
-
-
-# End Of Class
-
-# EOF

--- a/src/vtp/ops/setup_vtp_demo_operation.py
+++ b/src/vtp/ops/setup_vtp_demo_operation.py
@@ -17,10 +17,7 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""
-Library operation for command line level script set up a VTP demo
-See 'setup_vtp_demo -h' for usage information.
-"""
+"""Logic of operation for setting up a VTP demo."""
 
 # Standard imports
 import logging
@@ -33,11 +30,7 @@ from vtp.core.election_config import ElectionConfig
 
 
 class SetupVtpDemoOperation:
-    """
-    A class to implememt the setup-vtp-demo operation.  See the
-    setup-vtp-demo help output or read the parse_argument argparse
-    description (immediately below this) in the source file.
-    """
+    """Implementation of setup-vtp-demo."""
 
     def __init__(self, args):
         """Only to module-ize the scripts and keep things simple and idiomatic."""
@@ -133,8 +126,6 @@ class SetupVtpDemoOperation:
 
     # pylint: disable=duplicate-code
     def run(self):
-        """Main function - see -h for more info"""
-
         # Configure logging
         Common.configure_logging(self.args.verbosity)
 

--- a/src/vtp/ops/setup_vtp_demo_operation.py
+++ b/src/vtp/ops/setup_vtp_demo_operation.py
@@ -24,10 +24,11 @@ import logging
 import os
 import secrets
 
-# Local import
+# Project imports
 from vtp.core.common import Common, Globals, Shellout
 from vtp.core.election_config import ElectionConfig
 
+# Local imports
 from .operation import Operation
 
 

--- a/src/vtp/ops/show_contests_operation.py
+++ b/src/vtp/ops/show_contests_operation.py
@@ -23,10 +23,11 @@
 import logging
 import os
 
-# Local libraries
+# Project imports
 from vtp.core.common import Common, Globals, Shellout
 from vtp.core.election_config import ElectionConfig
 
+# Local imports
 from .operation import Operation
 
 

--- a/src/vtp/ops/show_contests_operation.py
+++ b/src/vtp/ops/show_contests_operation.py
@@ -17,10 +17,7 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""Library backend for command line level test script to automatically cast a ballot.
-
-See 'show_contest.py -h' for usage information.
-"""
+"""Logic of operation for showing contests."""
 
 # Standard imports
 import logging
@@ -33,11 +30,7 @@ from vtp.core.election_config import ElectionConfig
 
 
 class ShowContestsOperation:
-    """
-    A class to implememt the show-contests operation.  See the
-    show-contests help output or read the parse_argument argparse
-    description (immediately below this) in the source file.
-    """
+    """Implementation of 'show-contest' operation."""
 
     def __init__(self, args):
         """Only to module-ize the scripts and keep things simple and idiomatic."""
@@ -87,8 +80,6 @@ class ShowContestsOperation:
 
     # pylint: disable=duplicate-code
     def run(self):
-        """Main function - see -h for more info"""
-
         # Configure logging
         Common.configure_logging(self.args.verbosity)
 

--- a/src/vtp/ops/show_contests_operation.py
+++ b/src/vtp/ops/show_contests_operation.py
@@ -22,19 +22,26 @@
 # Standard imports
 import logging
 import os
-import re
 
 # Local libraries
 from vtp.core.common import Common, Globals, Shellout
 from vtp.core.election_config import ElectionConfig
 
+from .operation import Operation
 
-class ShowContestsOperation:
+
+class ShowContestsOperation(Operation):
     """Implementation of 'show-contest' operation."""
 
-    def __init__(self, args):
-        """Only to module-ize the scripts and keep things simple and idiomatic."""
-        self.args = args
+    def __init__(
+        self,
+        # TODO: Use `list[str]`
+        contest_check: str = "",
+        **base_options,
+    ):
+        """Create a show contest operation."""
+        super().__init__(**base_options)
+        self._contest_check = contest_check or []
 
     def validate_digests(self, digests, election_data_dir, error_digests):
         """Will scan the supplied digests for validity.  Will print and
@@ -51,7 +58,7 @@ class ShowContestsOperation:
                         "--batch-check=%(objectname) %(objecttype)",
                         "--buffer",
                     ],
-                    verbosity=self.args.verbosity,
+                    verbosity=self._verbosity,
                     input=input_data,
                     text=True,
                     check=True,
@@ -81,7 +88,7 @@ class ShowContestsOperation:
     # pylint: disable=duplicate-code
     def run(self):
         # Configure logging
-        Common.configure_logging(self.args.verbosity)
+        Common.configure_logging(self._verbosity)
 
         # Create a VTP ElectionData object if one does not already exist
         the_election_config = ElectionConfig.configure_election()
@@ -94,10 +101,10 @@ class ShowContestsOperation:
 
         # First validate the digests
         error_digests = set()
-        self.validate_digests(self.args.contest_check, election_data_dir, error_digests)
+        self.validate_digests(self._contest_check, election_data_dir, error_digests)
         valid_digests = [
             digest
-            for digest in self.args.contest_check.split(",")
+            for digest in self._contest_check.split(",")
             if digest not in error_digests
         ]
         # show/log the digests
@@ -107,15 +114,15 @@ class ShowContestsOperation:
 
 # For future reference just in case . . .
 # this is a loop of shell commands
-#        for digest in self.args.contest_check.split(','):
+#        for digest in self._contest_check.split(','):
 #            if digest not in error_digests:
 #                Shellout.run(['git', 'log', '-1', digest], check=True)
 
 # this does not work well enough either
-#        input_data = '\n'.join(self.args.contest_check.split(',')) + '\n'
+#        input_data = '\n'.join(self._contest_check.split(',')) + '\n'
 #        Shellout.run(
 #            ['git', 'cat-file', '--batch=%(objectname)'],
 #            input=input_data,
 #            text=True,
 #            check=True,
-#            verbosity=self.args.verbosity)
+#            verbosity=self._verbosity)

--- a/src/vtp/ops/tally_contests_operation.py
+++ b/src/vtp/ops/tally_contests_operation.py
@@ -17,12 +17,7 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""
-Library backend to command line level script to tally the contests of
-a election.
-
-See 'tally_contests.py -h' for usage information.
-"""
+"""Logic of operation for tallying contests."""
 
 # Standard imports
 import logging
@@ -38,11 +33,7 @@ from vtp.core.exceptions import TallyException
 
 # pylint: disable=too-few-public-methods
 class TallyContestsOperation:
-    """
-    A class to implememt the tally-contests operation.  See the
-    tally-contests help output or read the parse_argument argparse
-    description (immediately below this) in the source file.
-    """
+    """Implementation of 'tally-contests' operation."""
 
     def __init__(self, args):
         """Only to module-ize the scripts and keep things simple and idiomatic."""
@@ -50,8 +41,6 @@ class TallyContestsOperation:
 
     # pylint: disable=duplicate-code
     def run(self):
-        """Main function - see -h for more info"""
-
         # Configure logging
         Common.configure_logging(self.args.verbosity)
 

--- a/src/vtp/ops/verify_ballot_receipt_operation.py
+++ b/src/vtp/ops/verify_ballot_receipt_operation.py
@@ -25,7 +25,7 @@ import logging
 import os
 import re
 
-# Local import
+# Project imports
 from vtp.core.address import Address
 from vtp.core.ballot import Ballot
 from vtp.core.common import Common, Globals, Shellout

--- a/src/vtp/ops/verify_ballot_receipt_operation.py
+++ b/src/vtp/ops/verify_ballot_receipt_operation.py
@@ -43,8 +43,8 @@ class VerifyBallotReceiptOperation(Operation):
         receipt_file: str = "",
         row: str = "",
         cvr: bool = False,
-        do_not_pull = False,
-        **base_options
+        do_not_pull: bool = False,
+        **base_options,
     ):
         super().__init__(**base_options)
         self._address = address

--- a/src/vtp/ops/verify_ballot_receipt_operation.py
+++ b/src/vtp/ops/verify_ballot_receipt_operation.py
@@ -17,12 +17,7 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""
-Library backend for command line level script to verify a
-voters ballot receipt.
-
-See 'verify_ballot_receipt.py -h' for usage information.
-"""
+"""Logic of operation for verifying receipt of a ballot."""
 
 # Standard imports
 import json
@@ -38,11 +33,7 @@ from vtp.core.election_config import ElectionConfig
 
 
 class VerifyBallotReceiptOperation:
-    """
-    A class to implememt the verify-ballot-receipt operation.  See the
-    verify-ballot-receipt help output or read the parse_argument argparse
-    description (immediately below this) in the source file.
-    """
+    """Implementation of 'verify-ballot-receipt' operation."""
 
     def __init__(self, args):
         """Only to module-ize the scripts and keep things simple and idiomatic."""
@@ -286,8 +277,6 @@ class VerifyBallotReceiptOperation:
 
     # pylint: disable=duplicate-code
     def run(self):
-        """Main function - see -h for more info"""
-
         # Configure logging
         Common.configure_logging(self.args.verbosity)
 

--- a/src/vtp/ops/vote_operation.py
+++ b/src/vtp/ops/vote_operation.py
@@ -17,12 +17,7 @@
 #   with this program; if not, write to the Free Software Foundation, Inc.,
 #   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""
-Library backend to command line level script to allow an end voter to
-vote - it simply wraps a call to cast_ballot.py and accept_ballot.py.
-
-See 'vote.py -h' for usage information.
-"""
+"""Logic of operation for voting."""
 
 from vtp.core.ballot import Ballot
 from vtp.core.common import Common, Shellout
@@ -35,19 +30,13 @@ from vtp.ops.cast_ballot_operation import CastBallotOperation
 
 # pylint: disable=too-few-public-methods
 class VoteOperation:
-    """
-    A class to implememt the vote operation.  See the
-    vote help output or read the parse_argument argparse
-    description (immediately below this) in the source file.
-    """
+    """Implementation of 'vote' operation."""
 
     def __init__(self, args):
         """Only to module-ize the scripts and keep things simple and idiomatic."""
         self.args = args
 
     def run(self):
-        """Main function - see -h for more info"""
-
         # Configure logging
         Common.configure_logging(self.args.verbosity)
 

--- a/src/vtp/ops/vote_operation.py
+++ b/src/vtp/ops/vote_operation.py
@@ -24,10 +24,6 @@ vote - it simply wraps a call to cast_ballot.py and accept_ballot.py.
 See 'vote.py -h' for usage information.
 """
 
-# Standard imports
-import argparse
-
-from vtp.core.address import Address
 from vtp.core.ballot import Ballot
 from vtp.core.common import Common, Shellout
 from vtp.core.election_config import ElectionConfig
@@ -45,59 +41,15 @@ class VoteOperation:
     description (immediately below this) in the source file.
     """
 
-    @staticmethod
-    def parse_arguments(argv):
-        """Parse arguments from a command line or from the constructor"""
-
-        safe_args = Common.cast_thing_to_list(argv)
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.RawDescriptionHelpFormatter,
-            description="""
-    Will interactively allow a voter to vote.  Internally it first calls
-    cast_balloy.py followed by accept_ballot.py.  If a specific election
-    address or a specific blank ballot is not specified, a random blank
-    ballot is chosen.
-    """,
-        )
-
-        Address.add_address_args(parser)
-        parser.add_argument(
-            "-m",
-            "--merge_contests",
-            action="store_true",
-            help="Will immediately merge the ballot contests (to main)",
-        )
-        parser.add_argument(
-            "--blank_ballot",
-            help="overrides an address - specifies the specific blank ballot",
-        )
-        parser.add_argument(
-            "-v",
-            "--verbosity",
-            type=int,
-            default=3,
-            help="0 critical, 1 error, 2 warning, 3 info, 4 debug (def=3)",
-        )
-        parser.add_argument(
-            "-n",
-            "--printonly",
-            action="store_true",
-            help="will printonly and not write to disk (def=True)",
-        )
-        return parser.parse_args(safe_args)
-
-    def __init__(self, unparsed_args):
+    def __init__(self, args):
         """Only to module-ize the scripts and keep things simple and idiomatic."""
-        self.parsed_args = VoteOperation.parse_arguments(unparsed_args)
+        self.args = args
 
-    ################
-    # main
-    ################
     def run(self):
         """Main function - see -h for more info"""
 
         # Configure logging
-        Common.configure_logging(self.parsed_args.verbosity)
+        Common.configure_logging(self.args.verbosity)
 
         # Create a VTP ElectionData object if one does not already exist
         the_election_config = ElectionConfig.configure_election()
@@ -108,34 +60,34 @@ class VoteOperation:
         with Shellout.changed_cwd(a_ballot.get_cvr_parent_dir(the_election_config)):
             Shellout.run(
                 ["git", "pull"],
-                printonly=self.parsed_args.printonly,
-                verbosity=self.parsed_args.verbosity,
+                printonly=self.args.printonly,
+                verbosity=self.args.verbosity,
                 check=True,
             )
 
         # If an address was used, use that
         cast_args = {
-            "verbosity": self.parsed_args.verbosity,
-            "printonly": self.parsed_args.printonly,
+            "verbosity": self.args.verbosity,
+            "printonly": self.args.printonly,
         }
         accept_args = {
-            "verbosity": self.parsed_args.verbosity,
-            "printonly": self.parsed_args.printonly,
+            "verbosity": self.args.verbosity,
+            "printonly": self.args.printonly,
         }
-        if not self.parsed_args.blank_ballot:
-            if self.parsed_args.state:
-                cast_args["state"] = self.parsed_args.state
-                accept_args["state"] = self.parsed_args.state
-            if self.parsed_args.town:
-                cast_args["town"] = self.parsed_args.town
-                accept_args["town"] = self.parsed_args.town
-            if self.parsed_args.substreet:
-                cast_args["substreet"] = self.parsed_args.substreet
-            if self.parsed_args.address:
-                cast_args["address"] = self.parsed_args.address
+        if not self.args.blank_ballot:
+            if self.args.state:
+                cast_args["state"] = self.args.state
+                accept_args["state"] = self.args.state
+            if self.args.town:
+                cast_args["town"] = self.args.town
+                accept_args["town"] = self.args.town
+            if self.args.substreet:
+                cast_args["substreet"] = self.args.substreet
+            if self.args.address:
+                cast_args["address"] = self.args.address
         else:
-            cast_args["blank_ballot"] = self.parsed_args.blank_ballot
-            accept_args["blank_ballot"] = self.parsed_args.blank_ballot
+            cast_args["blank_ballot"] = self.args.blank_ballot
+            accept_args["blank_ballot"] = self.args.blank_ballot
 
         # Basically only do as little as necessary to call cast_ballot.py
         # followed by accept_ballot.py
@@ -145,8 +97,3 @@ class VoteOperation:
         # Accept the ballot
         a_accept_ballot_operation = AcceptBallotOperation(accept_args)
         a_accept_ballot_operation.run()
-
-    # End Of Class
-
-
-# EOF

--- a/src/vtp/ops/vote_operation.py
+++ b/src/vtp/ops/vote_operation.py
@@ -19,15 +19,16 @@
 
 """Logic of operation for voting."""
 
+# Project imports
 from vtp.core.address import Address
 from vtp.core.ballot import Ballot
 from vtp.core.common import Common, Shellout
 from vtp.core.election_config import ElectionConfig
 
-# Local libraries
+# Local imports
 from .operation import Operation
-from vtp.ops.accept_ballot_operation import AcceptBallotOperation
-from vtp.ops.cast_ballot_operation import CastBallotOperation
+from .accept_ballot_operation import AcceptBallotOperation
+from .cast_ballot_operation import CastBallotOperation
 
 
 # pylint: disable=too-few-public-methods


### PR DESCRIPTION
Move all argument parsing into `vtp.cli` and make operations in `vtp.ops` independent of it. 
There are improvements like putting all parameter constants into one module which would make 
the code cleaner but are not within scope.

This work is designed to prepare the way for unit tests.

