### PR TITLE
Feature/87 bool contests should be str too

### DIFF
--- a/src/vtp/core/contest.py
+++ b/src/vtp/core/contest.py
@@ -74,14 +74,17 @@ class Contest:
         ticket_names.  A a_c_blob can be either a_contest_blob or
         a_cvr_blob.
         """
-        # a_c_blob is a length one dict keyed on contest name - need the
-        # value for just about everything.
-        contest_value = next(iter(a_c_blob.values()))
+        # Note - a a_contest_blob is a length one dict keyed on
+        # contest name - the desired dict is the value of this one and
+        # only key.  But if the a_c_blob is a a_contest_blob, then it
+        # is already the desired dict.  Sorry.
+        if "cast_branch" in a_c_blob:
+            contest_dict = a_c_blob
+        else:
+            contest_dict = next(iter(a_c_blob.values()))
         # if this is a ticket contest, need to validate uber ticket syntax
         check_ticket = (
-            True
-            if "contest_type" in contest_value and "ticket" == contest_value["contest_type"]
-            else False
+            "contest_type" in contest_dict and contest_dict["contest_type"] == "ticket"
         )
         for choice in choices:
             if isinstance(choice, str):
@@ -98,7 +101,9 @@ class Contest:
                         raise KeyError(
                             "Contest type is a ticket contest but does not contain ticket_names"
                         )
-                    if len(choice["ticket_names"]) != len(contest_value["ticket_offices"]):
+                    if len(choice["ticket_names"]) != len(
+                        contest_dict["ticket_offices"]
+                    ):
                         raise KeyError(
                             "when either 'ticket_names' or 'ticket_offices' are specified"
                             "the length of each array mush match - "
@@ -106,7 +111,7 @@ class Contest:
                         )
                     if not isinstance(choice["ticket_names"], list):
                         raise KeyError("the key 'ticket_names' can only be a list")
-                    if not isinstance(contest_value["ticket_offices"], list):
+                    if not isinstance(contest_dict["ticket_offices"], list):
                         raise KeyError("the key 'ticket_names' can only be a list")
                 elif "ticket_names" in choice:
                     raise KeyError(

--- a/src/vtp/core/contest.py
+++ b/src/vtp/core/contest.py
@@ -32,10 +32,19 @@ class Contest:
 
     # Legitimate Contest keys.  Note 'selection', 'uid', 'cloak', and
     # 'name' are not legitimate keys for blank ballots
-    _config_keys = ["choices", "tally", "win-by", "max", "write-in", "description"]
+    _config_keys = [
+        "choices",
+        "tally",
+        "win-by",
+        "max",
+        "write-in",
+        "description",
+        "contest_type",
+        "ticket_offices",
+    ]
     _blank_ballot_keys = _config_keys + ["uid"]
     _cast_keys = _blank_ballot_keys + ["selection", "name", "cast_branch", "ggo"]
-    _choice_keys = ["name", "party", "ticket_names", "ticket_offices"]
+    _choice_keys = ["name", "party", "ticket_names"]
 
     # A simple numerical n digit uid
     _uids = {}
@@ -57,8 +66,23 @@ class Contest:
         Contest._nextuid += 1
 
     @staticmethod
-    def check_contest_choices(choices):
-        """Will validate the syntax of the contest choice"""
+    def check_contest_choices(choices: list, a_c_blob: dict):
+        """
+        Will validate the syntax of the contest choices.  To validate
+        a ticket contest, the outer context node now contains the
+        ticket_offices while the inner node choice contains the paired
+        ticket_names.  A a_c_blob can be either a_contest_blob or
+        a_cvr_blob.
+        """
+        # a_c_blob is a length one dict keyed on contest name - need the
+        # value for just about everything.
+        contest_value = next(iter(a_c_blob.values()))
+        # if this is a ticket contest, need to validate uber ticket syntax
+        check_ticket = (
+            True
+            if "contest_type" in contest_value and "ticket" == contest_value["contest_type"]
+            else False
+        )
         for choice in choices:
             if isinstance(choice, str):
                 continue
@@ -69,22 +93,25 @@ class Contest:
                         "the following keys are not valid Contest choice keys: "
                         f"{','.join(bad_keys)}"
                     )
-                if "ticket_names" in choice or "ticket_offices" in choice:
-                    if len(choice["ticket_names"]) != len(choice["ticket_names"]):
+                if check_ticket:
+                    if "ticket_names" not in choice:
+                        raise KeyError(
+                            "Contest type is a ticket contest but does not contain ticket_names"
+                        )
+                    if len(choice["ticket_names"]) != len(contest_value["ticket_offices"]):
                         raise KeyError(
                             "when either 'ticket_names' or 'ticket_offices' are specified"
                             "the length of each array mush match - "
                             f"{len(choice['ticket_names'])} != {len(choice['ticket_names'])}"
                         )
-                    if "ticket_names" not in choice or "ticket_offices" not in choice:
-                        raise KeyError(
-                            "both 'ticket_names' and 'ticket_offices' "
-                            "are required if either is specified"
-                        )
                     if not isinstance(choice["ticket_names"], list):
                         raise KeyError("the key 'ticket_names' can only be a list")
-                    if not isinstance(choice["ticket_offices"], list):
+                    if not isinstance(contest_value["ticket_offices"], list):
                         raise KeyError("the key 'ticket_names' can only be a list")
+                elif "ticket_names" in choice:
+                    raise KeyError(
+                        "Contest type is not a ticket contest but contains ticket_names"
+                    )
                 continue
             if isinstance(choice, bool):
                 continue
@@ -125,7 +152,7 @@ class Contest:
                 f"{','.join(bad_keys)}"
             )
         # Need to validate choices sub data structure as well
-        Contest.check_contest_choices(a_contest_blob[name]["choices"])
+        Contest.check_contest_choices(a_contest_blob[name]["choices"], a_contest_blob)
         # good enough
         return name
 
@@ -153,7 +180,7 @@ class Contest:
                 f"{','.join(bad_keys)}"
             )
         # Need to validate choices sub data structure as well
-        Contest.check_contest_choices(a_cvr_blob["choices"])
+        Contest.check_contest_choices(a_cvr_blob["choices"], a_cvr_blob)
 
     @staticmethod
     def get_choices_from_contest(choices):
@@ -168,7 +195,7 @@ class Contest:
         if isinstance(choices[0], dict):
             return [entry["name"] for entry in choices]
         if isinstance(choices[0], bool):
-            return ["yes", "no"] if choices[0] else ["no", "yes"]
+            return ["True", "False"] if choices[0] else ["False", "True"]
         raise ValueError(
             f"unknown/unsupported contest choices data structure ({choices})"
         )
@@ -222,9 +249,7 @@ class Contest:
         if "ticket_names" in self.contest["choices"][choice_index]:
             return {
                 "ticket_names": self.contest["choices"][choice_index]["ticket_names"],
-                "ticket_offices": self.contest["choices"][choice_index][
-                    "ticket_offices"
-                ],
+                "ticket_offices": self.contest["ticket_offices"],
             }
         return None
 
@@ -397,7 +422,7 @@ class Tally:
         if isinstance(pick, dict):
             return pick["name"]
         if isinstance(pick, bool):
-            return "yes" if pick else "no"
+            return "True" if pick else "False"
         raise ValueError(f"unknown/unsupported contest choices data structure ({pick})")
 
     def tally_a_plurality_contest(self, contest, provenance_digest):

--- a/src/vtp/core/contest.py
+++ b/src/vtp/core/contest.py
@@ -66,6 +66,7 @@ class Contest:
         Contest._nextuid += 1
 
     @staticmethod
+    # pylint: disable=too-many-branches
     def check_contest_choices(choices: list, a_c_blob: dict):
         """
         Will validate the syntax of the contest choices.  To validate

--- a/src/vtp/core/election_config.py
+++ b/src/vtp/core/election_config.py
@@ -196,7 +196,7 @@ class ElectionConfig:
         if os.path.isfile(filename):
             logging.debug("Reading %s", filename)
             with open(filename, "r", encoding="utf8") as map_file:
-                this_address_map = yaml.load(map_file, Loader=yaml.FullLoader)
+                this_address_map = yaml.load(map_file, Loader=yaml.BaseLoader)
             # sanity-check it
             ElectionConfig.check_address_map_syntax(this_address_map, filename)
             return this_address_map
@@ -209,7 +209,7 @@ class ElectionConfig:
         """
         logging.debug("Reading %s", filename)
         with open(filename, "r", encoding="utf8") as config_file:
-            config = yaml.load(config_file, Loader=yaml.FullLoader)
+            config = yaml.load(config_file, Loader=yaml.BaseLoader)
         # sanity-check it
         ElectionConfig.check_config_syntax(config, filename)
         # should really sanity check the contests too
@@ -217,6 +217,7 @@ class ElectionConfig:
             for contest in config["contests"]:
                 Contest.check_contest_blob_syntax(contest, filename)
                 Contest.set_uid(contest, ".")
+        #        import pdb; pdb.set_trace()
         return config
 
     def __init__(self, election_data_dir: str = "."):


### PR DESCRIPTION
Manual testing looks ok . . .

Yes/No choices are no longer translated to booleans.

Moved the ticket_offices JSON node out of the choices JSON node and up into the outer contest JSON node.  Now there is only one instance of this data per contest.

Fixed up the contestant names again.