### PR TITLE
Feature/89 the vtp rcv algorithm is buggy

### DIFF
--- a/src/vtp/core/contest.py
+++ b/src/vtp/core/contest.py
@@ -654,7 +654,11 @@ class Tally:
             if not contest["selection"]:
                 continue
             for last_place_name in last_place_names:
+                # Note - as the rounds go by, the
+                # contest["selection"]'s will get trimmed to an empty
+                # list.  Once empty, the vote/voter is done.
                 if (
+                    contest["selection"] and
                     self.select_name_from_choices(contest["selection"][0])
                     == last_place_name
                 ):

--- a/src/vtp/core/contest.py
+++ b/src/vtp/core/contest.py
@@ -475,16 +475,19 @@ class Tally:
         """
         logging.info("%s", self.rcv_round[current_round])
 
+        # Note - current_round is 0 indexed from left, which means it
+        # needs an additional decrement when indexing from the right
         if (
             Tally.get_choices_from_round(self.rcv_round[current_round], "count")[
-                -current_round
+                -current_round - 1
             ]
             == Tally.get_choices_from_round(self.rcv_round[current_round], "count")[
-                -current_round - 1
+                -current_round - 2
             ]
         ):
             # There are two last_place_name choices - will need
             # more code to handle this situation post the MVP demo
+            # import pdb; pdb.set_trace()
             raise TallyException(
                 f"There are two last place choices in contest {self.contest['name']} "
                 f"(uid={self.contest['uid']}) in round {current_round}.  "
@@ -504,11 +507,13 @@ class Tally:
                     f"has ended with a tie in round {current_round}: "
                     f"{self.rcv_round[current_round][0]} and {self.rcv_round[current_round][1]}\n"
                 )
-            raise TallyException(
-                "There are only two surviving RCV choices remaining and no winner."
-                f"There are two last place choices in contest {self.contest['name']} "
-                f"(uid={self.contest['uid']}) in round {current_round}."
-            )
+            # However, when there are only two selections left in the
+            # last round, the one with the greater count still wins
+            # raise TallyException(
+            #     "There are only two surviving RCV choices remaining and no winner."
+            #     f"There are two last place choices in contest {self.contest['name']} "
+            #     f"(uid={self.contest['uid']}) in round {current_round}."
+            # )
         # loop over the current round and try to find a legit
         # last_place_name
         offset = len(self.rcv_round[current_round])


### PR DESCRIPTION
Slightly refactored the contest.py file to explicitly break out the next_rcv_round_precheck and recast_votes functions.  Note that the precheck will probably change with increased information on how RCV 'should' actually work.  However, since this may end up to be a political or personal decision, at that time configuration constants can be added.